### PR TITLE
fix: issues #16-19 — emergency overlay, NOTAM flood, offline editing, fuel stop delete

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,6 @@ Standard Capacitor/Gradle project. Mixed HTTP content is explicitly allowed in t
 | `web/cockpit-config.json` | UI defaults: map layers, overlays, chart limits, FIS-B settings |
 | `web/aircraft-config.json` | Aircraft performance: speeds, power settings, W&B (RV-9A N194JT) |
 | `web/checklist.json` | VFR checklist sections |
-| `web/version.json` | Version tracking |
 | `capacitor.config.ts` | Capacitor/Android settings |
 
 ## Key Conventions

--- a/README.md
+++ b/README.md
@@ -137,7 +137,6 @@ Home server (:8090)  ──HTTP──▶  map tiles, plates, NASR, CIFP
 | `web/cockpit-config.json`  | UI settings: map layers, overlays, radar, FIS-B, home server URLs          |
 | `web/aircraft-config.json` | Aircraft performance: V-speeds, fuel capacity, glide ratio, power settings |
 | `web/checklist.json`       | Checklist sections and items                                               |
-| `web/version.json`         | App version                                                                |
 
 The in-app **Configuration** page (MORE → ⚙) provides a GUI editor for all settings. Values are stored in `localStorage` and override the bundled JSON defaults.
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "app.flywhere.flytab"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 474
-        versionName "4.74"
+        versionCode 487
+        versionName "4.87"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,7 @@
  * Android Capacitor cockpit app. All data local. Pi for live telemetry only.
  */
 
-const FLYTAB_VERSION = 'v4.74';
+const FLYTAB_VERSION = 'v4.76';
 
 // ========== Diagnostic Logger (ring buffer in localStorage) ==========
 const DiagLog = (() => {

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,7 @@
  * Android Capacitor cockpit app. All data local. Pi for live telemetry only.
  */
 
-const FLYTAB_VERSION = 'v4.76';
+const FLYTAB_VERSION = 'v4.87';
 
 // ========== Diagnostic Logger (ring buffer in localStorage) ==========
 const DiagLog = (() => {
@@ -105,6 +105,14 @@ class FlyTabApp {
         this._clockInterval = null;
         this._recorderInterval = null;
         this._piConnected = false;
+
+        // FIS-B badge opens FIS-B status page
+        if (this.dom.statusFisb) {
+            this.dom.statusFisb.style.cursor = 'pointer';
+            this.dom.statusFisb.addEventListener('click', () => {
+                if (this.fisbStatus) this.fisbStatus.show();
+            });
+        }
     }
 
     async init() {
@@ -617,6 +625,11 @@ class FlyTabApp {
             this.cockpitMap.setFisbWeather(this.fisbWeather);
         }
 
+        // FIS-B Status overlay (reception health, tower list, product grid)
+        if (typeof FisbStatus !== 'undefined' && this.fisbClient) {
+            this.fisbStatus = new FisbStatus(this.stratuxClient, this.fisbClient);
+        }
+
         // Lightning strikes (Blitzortung WebSocket)
         if (typeof LightningLayer !== 'undefined') {
             this.lightning = new LightningLayer();
@@ -781,6 +794,7 @@ class FlyTabApp {
                 approachCharts: this.approachCharts,
                 fuelOverlay: this.fuelOverlay,
                 dataStatus: this.dataStatus,
+                fisbStatus: this.fisbStatus,
                 configEditor: this.configEditor,
                 ifrClearance: this.ifrClearance,
                 wxBriefing: this.wxBriefing,
@@ -1159,10 +1173,11 @@ class FlyTabApp {
             this.approachCharts.setRouteAirports(icaoList);
         }
 
-        // Update FIS-B weather strip with route airports
-        if (this.fisbWeather) {
+        // Update FIS-B weather strip and status page with route airports
+        if (this.fisbWeather || this.fisbStatus) {
             const icaoList = wps.map(wp => wp.icao).filter(Boolean);
-            this.fisbWeather.setRouteAirports(icaoList);
+            if (this.fisbWeather) this.fisbWeather.setRouteAirports(icaoList);
+            if (this.fisbStatus) this.fisbStatus.setRouteAirports(icaoList);
         }
 
 

--- a/web/cockpit/airport-popup.js
+++ b/web/cockpit/airport-popup.js
@@ -344,6 +344,7 @@ class AirportPopup {
             <div class="apt-tab-pane active" data-pane="info">
                 ${this._aptFactsHtml(apt)}
                 ${this._frequenciesHtml(apt.frequencies || [], apt.tower)}
+                ${this._fuelHtml(apt)}
                 ${(CockpitConfig.get('ifr.showCdPhone') || CockpitConfig.get('ifr.showCraft')) ? this._ifrHtml(apt) : ''}
             </div>
             <div class="apt-tab-pane" data-pane="wx">
@@ -502,6 +503,31 @@ class AirportPopup {
             const apt = await this._nasr.getAirport(icao);
             if (apt) {
                 if (latlng) { apt.lat = latlng[0]; apt.lon = latlng[1]; }
+                // Fetch runway data from AWC if missing from NASR bundle
+                if (!apt.runways?.length) {
+                    try {
+                        const resp = await fetch(
+                            `https://aviationweather.gov/api/data/airport?ids=${encodeURIComponent(icao)}&format=json`,
+                            { signal: AbortSignal.timeout(5000) }
+                        );
+                        if (resp.ok) {
+                            const data = await resp.json();
+                            const awc = Array.isArray(data) ? data[0] : data;
+                            if (awc?.runways?.length) {
+                                apt.runways = awc.runways.map(r => {
+                                    const [len, wid] = (r.dimension || '').split('x').map(Number);
+                                    return { id: r.id, length_ft: len || 0, width_ft: wid || 0, surface: r.surface || '' };
+                                });
+                                // Cache on the NASR record
+                                try {
+                                    const db = await this._nasr.open();
+                                    const tx = db.transaction('airports', 'readwrite');
+                                    tx.objectStore('airports').put(apt);
+                                } catch { /* non-critical */ }
+                            }
+                        }
+                    } catch { /* offline */ }
+                }
                 this.show(apt);
             } else {
                 // NASR not loaded yet (offline, first use) — show panel with stub so user knows why
@@ -1035,13 +1061,22 @@ class AirportPopup {
         const facts = [];
         if (apt.elev_ft != null) facts.push({ label: 'ELEV', value: `${apt.elev_ft} ft` });
         if (apt.tpa_ft)          facts.push({ label: 'TPA',  value: `${apt.tpa_ft} ft` });
-        if (apt.fuel)            facts.push({ label: 'FUEL', value: apt.fuel });
         if (apt.longest_rwy_ft)  facts.push({ label: 'RWY',  value: `${apt.longest_rwy_ft} ft` });
+        // Runway directions (e.g. "34/16")
+        if (apt.runways?.length) {
+            const dirs = apt.runways.map(r => r.id || '').filter(Boolean).join(', ');
+            if (dirs) facts.push({ label: 'DIR', value: dirs });
+        }
         if (!facts.length) return '';
         const cells = facts.map(f =>
             `<div class="apt-fact"><div class="apt-fact-label">${f.label}</div><div class="apt-fact-value">${f.value}</div></div>`
         ).join('');
         return `<div class="popup-section apt-facts-row">${cells}</div>`;
+    }
+
+    _fuelHtml(apt) {
+        if (!apt.fuel) return '';
+        return `<div class="popup-section apt-facts-row"><div class="apt-fact"><div class="apt-fact-label">FUEL</div><div class="apt-fact-value">${apt.fuel}</div></div></div>`;
     }
 
     _frequenciesHtml(frequencies, isTowered) {

--- a/web/cockpit/emergency-glide.js
+++ b/web/cockpit/emergency-glide.js
@@ -59,7 +59,7 @@ class EmergencyGlide {
         const sit = window.app?.stratuxClient?.situation ?? window.stratuxClient?.situation;
         const lat = sit?.lat;
         const lon = sit?.lon;
-        const altMsl = sit?.alt_msl ?? 0;
+        const altMsl = sit?.alt_msl ?? sit?.alt_baro ?? 0;
 
         if (!lat || !lon) {
             console.warn('[EmergencyGlide] No GPS position — cannot compute glide range');
@@ -340,6 +340,7 @@ class EmergencyGlide {
         footer.appendChild(btn);
         el.appendChild(footer);
 
+        document.body.classList.add('emergency-active');
         document.body.appendChild(el);
         this._overlay = el;
 
@@ -420,6 +421,7 @@ class EmergencyGlide {
             <div class="eg-footer">
                 <button class="eg-ack-btn" id="egAckBtn">ACKNOWLEDGE</button>
             </div>`;
+        document.body.classList.add('emergency-active');
         document.body.appendChild(el);
         el.querySelector('#egAckBtn').addEventListener('click',
             () => this._dismissOverlay(), { once: true });
@@ -428,6 +430,7 @@ class EmergencyGlide {
 
     _dismissOverlay() {
         this._stopApproachMonitor();
+        document.body.classList.remove('emergency-active');
         if (this._overlay) {
             this._overlay.remove();
             this._overlay = null;

--- a/web/cockpit/emergency-glide.js
+++ b/web/cockpit/emergency-glide.js
@@ -593,7 +593,7 @@ class EmergencyGlide {
 
         const distNm = NasrDB.haversineNm(sit.lat, sit.lon, apt.lat, apt.lon);
         const hdg = this._bearingTo(sit.lat, sit.lon, apt.lat, apt.lon);
-        const altMsl = sit.alt_msl ?? 0;
+        const altMsl = sit.alt_msl ?? sit.alt_baro ?? 0;
         const vs = Math.round(sit.vertical_speed ?? 0);
         const gs = Math.max(sit.ground_speed ?? 0, 30); // floor to avoid div/0
 

--- a/web/cockpit/fisb-status.js
+++ b/web/cockpit/fisb-status.js
@@ -1,0 +1,284 @@
+/**
+ * FlyTab — FIS-B Status Page
+ * Full-screen overlay showing FIS-B reception health, tower list,
+ * product freshness table, and route-aware weather coverage.
+ * Reads from existing StratuxClient + FisbClient — no new connections.
+ */
+
+class FisbStatus {
+    static PRODUCTS = [
+        { key: 'METAR',    label: 'METAR / SPECI',     interval: 300,  store: 'metars',  type: 'map' },
+        { key: 'TAF',      label: 'TAF',               interval: 720,  store: 'tafs',    type: 'map' },
+        { key: 'SIGMET',   label: 'SIGMET',            interval: 300,  store: 'sigmets',  type: 'array' },
+        { key: 'AIRMET',   label: 'AIRMET',            interval: 300,  store: 'airmets',  type: 'array' },
+        { key: 'PIREP',    label: 'PIREP',             interval: 600,  store: 'pireps',   type: 'array' },
+        { key: 'WINDS',    label: 'Winds Aloft',       interval: 720,  store: 'winds',    type: 'map' },
+        { key: 'NOTAM',    label: 'NOTAM / TFR',       interval: 600,  store: 'notams',   type: 'array' },
+        { key: 'NEXRAD_R', label: 'NEXRAD Regional',   interval: 150,  store: null,       type: 'nexrad' },
+        { key: 'NEXRAD_N', label: 'NEXRAD CONUS',      interval: 300,  store: null,       type: 'nexrad' },
+    ];
+
+    constructor(stratuxClient, fisbClient) {
+        this._stratux = stratuxClient;
+        this._fisb = fisbClient;
+        this._routeAirports = [];
+        this._renderTimer = null;
+        this._buildDOM();
+    }
+
+    show() {
+        this._el.classList.add('visible');
+        this._render();
+        this._renderTimer = setInterval(() => this._render(), 5000);
+    }
+
+    hide() {
+        this._el.classList.remove('visible');
+        if (this._renderTimer) { clearInterval(this._renderTimer); this._renderTimer = null; }
+    }
+
+    toggle() {
+        this._el.classList.contains('visible') ? this.hide() : this.show();
+    }
+
+    setRouteAirports(icaoList) {
+        this._routeAirports = (icaoList || []).map(s => s.toUpperCase());
+    }
+
+    // ========== DOM ==========
+
+    _buildDOM() {
+        this._el = document.createElement('div');
+        this._el.className = 'fisb-status-page';
+        this._el.innerHTML = `
+            <div class="fisb-header">
+                <span class="fisb-title">FIS-B STATUS</span>
+                <button class="fisb-close">✕</button>
+            </div>
+            <div class="fisb-body">
+                <div class="fisb-health-bar" id="fisbHealthBar"></div>
+                <div class="fisb-route-section" id="fisbRouteSection"></div>
+                <div class="fisb-section-label">PRODUCTS</div>
+                <table class="fisb-product-table">
+                    <thead>
+                        <tr>
+                            <th></th><th>PRODUCT</th><th>COUNT</th><th>AGE</th><th>STATIONS</th>
+                        </tr>
+                    </thead>
+                    <tbody id="fisbProductBody"></tbody>
+                </table>
+                <div class="fisb-section-label">TOWERS</div>
+                <div class="fisb-towers" id="fisbTowers"></div>
+            </div>
+        `;
+
+        this._el.querySelector('.fisb-close').addEventListener('click', () => this.hide());
+        // Block touch events from reaching map underneath
+        this._el.addEventListener('touchstart', (e) => e.stopPropagation(), { passive: true });
+
+        document.body.appendChild(this._el);
+    }
+
+    // ========== Render ==========
+
+    _render() {
+        this._renderHealthBar();
+        this._renderRouteCoverage();
+        this._renderProducts();
+        this._renderTowers();
+    }
+
+    _renderHealthBar() {
+        const s = this._stratux.deviceStatus || {};
+        const towers = Object.keys(this._stratux.towerData || {}).length;
+        const uatRate = s.UAT_messages_last_minute || 0;
+        const uatPeak = s.UAT_messages_max || 0;
+        const gps = s.GPS_satellites_locked || 0;
+        const cpu = s.CPUTemp != null ? s.CPUTemp.toFixed(1) : '--';
+
+        const totalProducts = (s.UAT_METAR_total || 0) + (s.UAT_TAF_total || 0) +
+            (s.UAT_NEXRAD_total || 0) + (s.UAT_SIGMET_total || 0) +
+            (s.UAT_PIREP_total || 0) + (s.UAT_NOTAM_total || 0);
+
+        const cells = [
+            { label: 'TOWERS',  value: towers, cls: towers >= 3 ? 'ok' : towers > 0 ? 'warn' : 'bad' },
+            { label: 'UAT/MIN', value: uatRate, cls: uatRate > 50 ? 'ok' : uatRate > 0 ? 'warn' : 'bad' },
+            { label: 'PEAK',    value: uatPeak, cls: '' },
+            { label: 'PRODUCTS',value: totalProducts.toLocaleString(), cls: totalProducts > 0 ? 'ok' : 'bad' },
+            { label: 'GPS',     value: gps > 0 ? `${gps} sat` : 'NO FIX', cls: gps >= 4 ? 'ok' : gps > 0 ? 'warn' : 'bad' },
+            { label: 'CPU',     value: `${cpu}\u00b0C`, cls: parseFloat(cpu) > 70 ? 'bad' : parseFloat(cpu) > 55 ? 'warn' : 'ok' },
+        ];
+
+        const el = this._el.querySelector('#fisbHealthBar');
+        el.innerHTML = cells.map(c =>
+            `<div class="fisb-hcell">
+                <div class="fisb-hcell-label">${c.label}</div>
+                <div class="fisb-hcell-value ${c.cls}">${c.value}</div>
+            </div>`
+        ).join('');
+    }
+
+    _renderRouteCoverage() {
+        const section = this._el.querySelector('#fisbRouteSection');
+        if (!this._routeAirports.length) {
+            section.innerHTML = '';
+            return;
+        }
+
+        const metars = this._fisb.metars;
+        const tafs = this._fisb.tafs;
+
+        let rows = '';
+        for (const icao of this._routeAirports) {
+            const hasMetar = metars.has(icao);
+            const hasTaf = tafs.has(icao);
+            const metarAge = hasMetar ? this._ageStr(metars.get(icao).received_at) : '--';
+            const tafAge = hasTaf ? this._ageStr(tafs.get(icao).received_at) : '--';
+
+            let rowClass = '';
+            if (!hasMetar && !hasTaf) rowClass = 'fisb-route-row missing';
+            else if (!hasMetar || !hasTaf) rowClass = 'fisb-route-row partial';
+            else rowClass = 'fisb-route-row';
+
+            const dot = (has) => has
+                ? '<span class="fisb-dot ok"></span>'
+                : '<span class="fisb-dot bad"></span>';
+
+            rows += `<tr class="${rowClass}">
+                <td class="fisb-route-icao">${icao}</td>
+                <td>${dot(hasMetar)} ${metarAge}</td>
+                <td>${dot(hasTaf)} ${tafAge}</td>
+            </tr>`;
+        }
+
+        section.innerHTML = `
+            <div class="fisb-section-label">ROUTE WEATHER</div>
+            <table class="fisb-route-table">
+                <thead><tr><th>AIRPORT</th><th>METAR</th><th>TAF</th></tr></thead>
+                <tbody>${rows}</tbody>
+            </table>
+        `;
+    }
+
+    _renderProducts() {
+        const tbody = this._el.querySelector('#fisbProductBody');
+        const routeSet = new Set(this._routeAirports);
+
+        let html = '';
+        for (const p of FisbStatus.PRODUCTS) {
+            const { count, newestAge, stations } = this._getProductStats(p);
+            const status = this._statusClass(newestAge, p.interval, count);
+
+            // Build station list — route airports bold and first
+            let stationHtml = '';
+            if (p.type === 'nexrad') {
+                stationHtml = count > 0 ? `<span class="fisb-station-dim">${count} frames</span>` : '--';
+            } else if (stations.length > 0) {
+                const route = stations.filter(s => routeSet.has(s));
+                const other = stations.filter(s => !routeSet.has(s));
+                const sorted = [...route, ...other];
+                stationHtml = sorted.map(s =>
+                    routeSet.has(s)
+                        ? `<span class="fisb-station route">${s}</span>`
+                        : `<span class="fisb-station">${s}</span>`
+                ).join(' ');
+            } else {
+                stationHtml = '<span class="fisb-station-dim">--</span>';
+            }
+
+            html += `<tr class="fisb-product-row ${status}">
+                <td><span class="fisb-dot ${status}"></span></td>
+                <td class="fisb-product-name">${p.label}</td>
+                <td class="fisb-product-count">${count || '--'}</td>
+                <td class="fisb-product-age">${count > 0 ? this._fmtAge(newestAge) : '--'}</td>
+                <td class="fisb-product-stations">${stationHtml}</td>
+            </tr>`;
+        }
+        tbody.innerHTML = html;
+    }
+
+    _renderTowers() {
+        const container = this._el.querySelector('#fisbTowers');
+        const entries = Object.entries(this._stratux.towerData || {});
+
+        if (entries.length === 0) {
+            container.innerHTML = '<div class="fisb-no-data">No towers in range</div>';
+            return;
+        }
+
+        entries.sort((a, b) => (b[1].Signal_strength_last_minute || 0) - (a[1].Signal_strength_last_minute || 0));
+
+        container.innerHTML = `<table class="fisb-tower-table">
+            <thead><tr><th>LOCATION</th><th>SIGNAL</th><th>MSG/MIN</th></tr></thead>
+            <tbody>${entries.map(([coords, t]) => {
+                const sig = t.Signal_strength_last_minute != null ? t.Signal_strength_last_minute.toFixed(0) : '?';
+                const sigNum = parseFloat(sig);
+                const cls = sigNum >= -10 ? 'ok' : sigNum >= -15 ? 'warn' : 'bad';
+                const lat = t.Lat != null ? t.Lat.toFixed(2) : '?';
+                const lng = t.Lng != null ? t.Lng.toFixed(2) : '?';
+                return `<tr>
+                    <td>${lat}, ${lng}</td>
+                    <td class="fisb-tower-sig ${cls}">${sig} dB</td>
+                    <td>${t.Messages_last_minute || 0}</td>
+                </tr>`;
+            }).join('')}</tbody>
+        </table>`;
+    }
+
+    // ========== Helpers ==========
+
+    _getProductStats(product) {
+        if (product.type === 'nexrad') {
+            const count = this._fisb.nexradBlockCount || 0;
+            return { count, newestAge: Infinity, stations: [] };
+        }
+
+        const store = this._fisb[product.store];
+        if (!store) return { count: 0, newestAge: Infinity, stations: [] };
+
+        if (product.type === 'map') {
+            let newestAge = Infinity;
+            const stations = [];
+            store.forEach((entry, key) => {
+                const age = (Date.now() - entry.received_at) / 1000;
+                if (age < newestAge) newestAge = age;
+                // For winds, key is "station:alt" — extract station
+                const station = product.key === 'WINDS' ? key.split(':')[0] : key;
+                if (!stations.includes(station)) stations.push(station);
+            });
+            return { count: store.size, newestAge, stations };
+        }
+
+        // Arrays (pireps, sigmets, airmets, notams)
+        let newestAge = Infinity;
+        const stations = [];
+        for (const entry of store) {
+            const age = (Date.now() - entry.received_at) / 1000;
+            if (age < newestAge) newestAge = age;
+            const loc = entry.icao || (entry.lat != null ? `${entry.lat.toFixed(1)},${entry.lon.toFixed(1)}` : '');
+            if (loc && !stations.includes(loc)) stations.push(loc);
+        }
+        return { count: store.length, newestAge, stations };
+    }
+
+    _statusClass(ageSec, interval, count) {
+        if (count === 0) return 'none';
+        if (!isFinite(ageSec)) return 'bad';
+        if (ageSec <= interval) return 'ok';
+        if (ageSec <= interval * 2) return 'warn';
+        return 'bad';
+    }
+
+    _ageStr(receivedAt) {
+        if (!receivedAt) return '--';
+        const sec = (Date.now() - receivedAt) / 1000;
+        return this._fmtAge(sec);
+    }
+
+    _fmtAge(sec) {
+        if (!isFinite(sec) || sec < 0) return '--';
+        if (sec < 60) return `${Math.round(sec)}s`;
+        if (sec < 3600) return `${Math.floor(sec / 60)}m`;
+        return `${Math.floor(sec / 3600)}h${Math.floor((sec % 3600) / 60)}m`;
+    }
+}

--- a/web/cockpit/fisb-weather.js
+++ b/web/cockpit/fisb-weather.js
@@ -392,7 +392,11 @@ class FisbWeatherDisplay {
     _addNotam(notam) {
         const raw = notam.raw || '';
         const icaoStr = notam.icao ? `${notam.icao} ` : '';
-        this._toastAlert(`\ud83d\udccb NOTAM: ${icaoStr}${raw.slice(0, 80)}`, 'amber', 20000, raw);
+        // Only toast when there is decoded human-readable text — skip binary-encoded
+        // NOTAMs (product IDs 11/12) where raw is a JSON dump with no Text field.
+        if (notam.plain?.trim()) {
+            this._toastAlert(`\ud83d\udccb NOTAM: ${icaoStr}${raw.slice(0, 80)}`, 'amber', 20000, raw);
+        }
 
         if (notam.lat == null || notam.lon == null) return;
 

--- a/web/cockpit/logbook.js
+++ b/web/cockpit/logbook.js
@@ -525,7 +525,7 @@ class Logbook {
             aircraft_tail: CockpitConfig.aircraft('tail') || 'N00000',
             aircraft_id: CockpitConfig.aircraft('tail') || 'N00000',
             aircraft_type: CockpitConfig.aircraft('type') || 'Unknown',
-            point_count: engData?.csv_points || 0,
+            point_count: flightDetail.rowCount || 0,
             source: 'flypi',
             draft: true,    // Draft until pilot reviews and edits
             created_at: new Date().toISOString(),

--- a/web/cockpit/map.js
+++ b/web/cockpit/map.js
@@ -1029,7 +1029,42 @@ class CockpitMap {
 
     async _drawDestRunways(icao) {
         const apt = await this._nasr.getAirport(icao);
-        if (!apt?.runways?.length) return;
+        if (!apt) return;
+
+        // Fetch runway data from AWC if not in NASR bundle
+        if (!apt.runways?.length) {
+            try {
+                const resp = await fetch(
+                    `https://aviationweather.gov/api/data/airport?ids=${encodeURIComponent(icao)}&format=json`,
+                    { signal: AbortSignal.timeout(5000) }
+                );
+                if (resp.ok) {
+                    const data = await resp.json();
+                    const awcApt = Array.isArray(data) ? data[0] : data;
+                    if (awcApt?.runways?.length) {
+                        apt.runways = awcApt.runways.map(r => {
+                            const [len, wid] = (r.dimension || '').split('x').map(Number);
+                            return {
+                                id: r.id,
+                                length_ft: len || 0,
+                                width_ft: wid || 0,
+                                surface: r.surface || '',
+                            };
+                        });
+                        // Cache on the NASR record for future use
+                        if (this._nasr?.open) {
+                            try {
+                                const db = await this._nasr.open();
+                                const tx = db.transaction('airports', 'readwrite');
+                                tx.objectStore('airports').put(apt);
+                            } catch { /* non-critical */ }
+                        }
+                    }
+                }
+            } catch { /* offline or timeout — no extensions */ }
+        }
+
+        if (!apt.runways?.length) return;
         this._destAirport = apt;
         this._rwyExtLayer = L.layerGroup();
         if (this._rwyExtVisible) this._rwyExtLayer.addTo(this.map);

--- a/web/cockpit/route-editor.js
+++ b/web/cockpit/route-editor.js
@@ -137,6 +137,7 @@ class RouteEditor {
         this._expandedIndex = -1;
         this._renderWaypoints();
         if (this._undoBtn) this._undoBtn.disabled = this._undoStack.length === 0;
+        this._applyRoute({ hide: false, toast: false });
     }
 
     // ========== Waypoint Operations ==========
@@ -150,6 +151,7 @@ class RouteEditor {
         }
         this._insertIndex = -1;
         this._renderWaypoints();
+        this._applyRoute({ hide: false, toast: false });
     }
 
     _removeWaypoint(index) {
@@ -158,6 +160,7 @@ class RouteEditor {
         this._waypoints.splice(index, 1);
         this._expandedIndex = -1;
         this._renderWaypoints();
+        this._applyRoute({ hide: false, toast: false });
     }
 
     _moveWaypoint(fromIdx, toIdx) {
@@ -168,6 +171,7 @@ class RouteEditor {
         this._waypoints.splice(toIdx, 0, wp);
         this._expandedIndex = toIdx;
         this._renderWaypoints();
+        this._applyRoute({ hide: false, toast: false });
     }
 
     // ========== Build DOM ==========
@@ -194,7 +198,6 @@ class RouteEditor {
                     <span class="route-editor-alt-unit">ft</span>
                 </div>
                 <div class="route-editor-actions">
-                    <button class="btn btn-primary route-editor-save">SAVE &amp; APPLY</button>
                     <button class="btn btn-secondary route-editor-undo" disabled>UNDO</button>
                 </div>
             </div>
@@ -218,7 +221,6 @@ class RouteEditor {
         this._wireTap(this._el.querySelector('.route-editor-go-btn'), () => this._onSearchInput());
         this._wireTap(this._el.querySelector('.route-editor-nearby-btn'), () => this._showNearby());
         this._wireTap(this._el.querySelector('.route-editor-maptap-btn'), () => this._toggleMapTapMode());
-        this._wireTap(this._el.querySelector('.route-editor-save'), () => this._applyRoute());
         this._wireTap(this._undoBtn, () => this._popUndo());
         this._altInput.addEventListener('change', () => {
             this._altitude = parseInt(this._altInput.value) || 3500;
@@ -835,6 +837,7 @@ class RouteEditor {
                 this._expandedIndex = -1;
                 this._renderWaypoints();
                 this._clearSearch();
+                this._applyRoute();
             });
         }
     }
@@ -958,7 +961,7 @@ class RouteEditor {
 
     // ========== Apply / Persist ==========
 
-    async _applyRoute() {
+    async _applyRoute({ hide = true, toast = true } = {}) {
         if (this._waypoints.length === 0) {
             if (typeof app !== 'undefined') app.showToast('Add at least one waypoint', 'amber');
             return;
@@ -1007,11 +1010,13 @@ class RouteEditor {
         }
 
         // Toast
-        const routeStr = wps.map(w => w.icao || w.name).join(' \u2192 ');
-        if (typeof app !== 'undefined') {
-            app.showToast(`Route updated: ${routeStr}`);
+        if (toast) {
+            const routeStr = wps.map(w => w.icao || w.name).join(' \u2192 ');
+            if (typeof app !== 'undefined') {
+                app.showToast(`Route updated: ${routeStr}`);
+            }
         }
 
-        this.hide();
+        if (hide) this.hide();
     }
 }

--- a/web/cockpit/route-editor.js
+++ b/web/cockpit/route-editor.js
@@ -23,6 +23,7 @@ class RouteEditor {
         this._mapTapMode = false;
         this._mapTapHandler = null;
         this._plan = null; // reference to loaded plan for metadata
+        this._parseSeq = 0; // sequence counter to discard stale route parse results
     }
 
     init() {
@@ -104,7 +105,9 @@ class RouteEditor {
                         alt: 0,
                     }];
                 }
-            } catch { /* NASR not ready */ }
+            } catch {
+                // NASR DB not ready — user can still add waypoints manually
+            }
         }
 
         if (this._altInput) this._altInput.value = this._altitude;
@@ -263,7 +266,7 @@ class RouteEditor {
     }
 
     async _loadDirectToNearby() {
-        const sit = this.stratux.situation;
+        const sit = this.stratux?.situation;
         if (!sit || !sit.lat) {
             this._directToResults.innerHTML = '<div class="route-search-empty">No GPS position</div>';
             return;
@@ -278,7 +281,7 @@ class RouteEditor {
             this._renderDirectToResults(airports.slice(0, 5));
         } catch (err) {
             console.warn('Direct-To nearby error:', err);
-            this._directToResults.innerHTML = '<div class="route-search-empty">Airport data unavailable offline</div>';
+            this._directToResults.innerHTML = '<div class="route-search-empty">Airport database not available</div>';
         }
     }
 
@@ -293,13 +296,16 @@ class RouteEditor {
             try {
                 const results = await this.nasrDb.searchAll(q);
                 this._renderDirectToResults(results.airports || [], results.navaids || [], results.fixes || [], q);
-            } catch {}
+            } catch (err) {
+                console.warn('Direct-To search error:', err);
+                this._directToResults.innerHTML = '<div class="route-search-empty">Airport database not available</div>';
+            }
         }, 200);
     }
 
     _renderDirectToResults(airports, navaids, fixes, query = '') {
         const q = (query || '').toUpperCase();
-        const sit = this.stratux.situation;
+        const sit = this.stratux?.situation;
         const results = [];
 
         for (const a of airports) {
@@ -360,7 +366,7 @@ class RouteEditor {
 
     _executeDirectTo(apt) {
         this._pushUndo();
-        const sit = this.stratux.situation;
+        const sit = this.stratux?.situation;
 
         const directWp = {
             icao: apt.icao,
@@ -519,6 +525,7 @@ class RouteEditor {
                         icao: `${lat.toFixed(2)}/${lng.toFixed(2)}`,
                         name: `${lat.toFixed(2)}/${lng.toFixed(2)}`,
                         lat, lon: lng, alt: this._altitude,
+                        type: 'GPS',
                     }, idx);
                 }
             } catch {
@@ -528,6 +535,7 @@ class RouteEditor {
                     icao: `${lat.toFixed(2)}/${lng.toFixed(2)}`,
                     name: `${lat.toFixed(2)}/${lng.toFixed(2)}`,
                     lat, lon: lng, alt: this._altitude,
+                    type: 'GPS',
                 }, idx);
             }
             this._disableMapTapMode();
@@ -553,7 +561,7 @@ class RouteEditor {
 
     _renderWaypoints() {
         if (!this._waypointsDiv) return;
-        const sit = this.stratux.situation;
+        const sit = this.stratux?.situation;
         const plan = this._plan || {};
         const startFuel = this._getStartFuel();
         const cruiseGph = plan.cruise_gph || 7;
@@ -761,6 +769,7 @@ class RouteEditor {
     }
 
     async _parseRouteString(str) {
+        const seq = ++this._parseSeq;
         const tokens = str.trim().split(/\s+/);
 
         // Show "Parsing..." immediately so user knows something is happening
@@ -784,12 +793,15 @@ class RouteEditor {
         };
 
         let { resolved, unresolved } = await doResolve();
+        if (seq !== this._parseSeq) return; // newer parse superseded this one
 
         // If nothing resolved (DB was likely blocked), wait and retry once
         if (resolved.length === 0 && unresolved.length > 0) {
             this._resultsDiv.innerHTML = '<div class="route-search-empty">Retrying...</div>';
             await new Promise(r => setTimeout(r, 1500));
+            if (seq !== this._parseSeq) return;
             ({ resolved, unresolved } = await doResolve());
+            if (seq !== this._parseSeq) return;
         }
 
         this._showRoutePreview(resolved, unresolved);
@@ -834,6 +846,8 @@ class RouteEditor {
             this._renderSearchResults(results.airports || [], results.navaids || [], results.fixes || [], query);
         } catch (err) {
             console.warn('[RouteEditor] Search error:', err);
+            this._resultsDiv.hidden = false;
+            this._resultsDiv.innerHTML = '<div class="route-search-empty">Airport database not available</div>';
         }
     }
 
@@ -923,7 +937,7 @@ class RouteEditor {
         } catch (err) {
             console.warn('[RouteEditor] Nearby error:', err);
             this._resultsDiv.hidden = false;
-            this._resultsDiv.innerHTML = '<div class="route-search-empty">Airport data unavailable offline</div>';
+            this._resultsDiv.innerHTML = '<div class="route-search-empty">Airport database not available</div>';
         }
     }
 
@@ -945,7 +959,10 @@ class RouteEditor {
     // ========== Apply / Persist ==========
 
     async _applyRoute() {
-        if (this._waypoints.length === 0) return;
+        if (this._waypoints.length === 0) {
+            if (typeof app !== 'undefined') app.showToast('Add at least one waypoint', 'amber');
+            return;
+        }
 
         // Build legs with course/distance
         const wps = this._waypoints.map((wp, i) => {

--- a/web/cockpit/route-editor.js
+++ b/web/cockpit/route-editor.js
@@ -278,6 +278,7 @@ class RouteEditor {
             this._renderDirectToResults(airports.slice(0, 5));
         } catch (err) {
             console.warn('Direct-To nearby error:', err);
+            this._directToResults.innerHTML = '<div class="route-search-empty">Airport data unavailable offline</div>';
         }
     }
 
@@ -921,6 +922,8 @@ class RouteEditor {
             this._renderSearchResults(airports.slice(0, 10), [], [], '');
         } catch (err) {
             console.warn('[RouteEditor] Nearby error:', err);
+            this._resultsDiv.hidden = false;
+            this._resultsDiv.innerHTML = '<div class="route-search-empty">Airport data unavailable offline</div>';
         }
     }
 

--- a/web/cockpit/route-editor.js
+++ b/web/cockpit/route-editor.js
@@ -127,7 +127,7 @@ class RouteEditor {
 
     _pushUndo() {
         this._undoStack.push(JSON.parse(JSON.stringify(this._waypoints)));
-        if (this._undoStack.length > 5) this._undoStack.shift();
+        if (this._undoStack.length > 15) this._undoStack.shift();
         if (this._undoBtn) this._undoBtn.disabled = false;
     }
 

--- a/web/cockpit/route-table.js
+++ b/web/cockpit/route-table.js
@@ -188,6 +188,12 @@ class RouteTable {
                     });
                 }
                 plan = { ...plan, waypoints: wps };
+
+                // Async NASR resolution: fill in lat/lon for waypoints reconstructed
+                // from legs so HDG/BRG/DIST columns show real values instead of dashes.
+                if (this._nasrDb) {
+                    this._resolveWaypointCoords(wps);
+                }
             }
         }
 
@@ -319,6 +325,45 @@ class RouteTable {
     }
 
     /**
+     * Attempt to resolve lat/lon for waypoints that are missing coordinates
+     * (e.g. reconstructed from a legs-only saved plan). Looks up each ident
+     * in NasrDB (airports → navaids → fixes) and patches the waypoint in-place,
+     * then recomputes the route so HDG/BRG/DIST columns populate.
+     */
+    async _resolveWaypointCoords(waypoints) {
+        const db = this._nasrDb;
+        if (!db) return;
+
+        let resolved = 0;
+        for (const wp of waypoints) {
+            if (wp.lat != null && wp.lon != null) continue;
+            const ident = wp.icao || wp.name;
+            if (!ident) continue;
+
+            try {
+                // Try airport first, then navaid, then fix
+                let rec = await db.getAirport(ident);
+                if (!rec) rec = await db.getAirport('K' + ident); // US ICAO prefix
+                if (!rec) rec = await db.getNavaid(ident);
+                if (!rec) rec = await db.getFix(ident);
+
+                if (rec && rec.lat != null && rec.lon != null) {
+                    wp.lat = rec.lat;
+                    wp.lon = rec.lon;
+                    if (rec.name && !wp.name) wp.name = rec.name;
+                    resolved++;
+                }
+            } catch { /* NASR DB may not be loaded yet — leave as dashes */ }
+        }
+
+        if (resolved > 0) {
+            this._computeEnroute();
+            this._updateSummary();
+            this._renderTable();
+        }
+    }
+
+    /**
      * Update live data (GS, position) from Stratux situation.
      */
     updateLive(situation) {
@@ -362,7 +407,11 @@ class RouteTable {
         // Skip full DOM rebuild while editing — live updates would destroy
         // the edit-mode button event listeners mid-interaction (issue #30)
         if (!this._editMode) {
-            this._renderTable();
+            // Try selective cell update first to avoid full innerHTML rebuild every
+            // GPS tick (1 Hz). Falls back to full render when structure changes.
+            if (!this._updateTableCells()) {
+                this._renderTable();
+            }
         }
     }
 
@@ -442,7 +491,7 @@ class RouteTable {
             waypoints: JSON.parse(JSON.stringify(this._waypoints)),
             activeIndex: this._activeIndex,
         });
-        if (this._undoStack.length > 5) this._undoStack.shift();
+        if (this._undoStack.length > 15) this._undoStack.shift();
     }
 
     _popUndo() {
@@ -2471,6 +2520,113 @@ class RouteTable {
 
         // All interactive events (edit buttons, power header, row clicks) handled
         // by delegated listeners on _tableEl set up in _buildDOM().
+    }
+
+    /**
+     * Selective cell update for live GPS ticks (non-edit mode only).
+     * Walks existing <tr> rows and patches cell text in-place instead of
+     * destroying/recreating the entire DOM tree. Returns false if the table
+     * structure has changed (row count or waypoint order) and a full rebuild
+     * is needed.
+     */
+    _updateTableCells() {
+        if (!this._tableEl) return false;
+        const columns = CockpitConfig.get('routeTable.columns') || [];
+        const rows = this._tableEl.querySelectorAll('tbody tr.rt-row');
+
+        // Build the expected list of (wp, seg, segIndex) tuples that _renderTable would emit
+        const expected = [];
+        const hasMultipleFlights = this._flights.length > 1;
+        const flightsToRender = hasMultipleFlights
+            ? this._flights
+            : [{ index: 0, depWpIndex: 0, destWpIndex: this._waypoints.length - 1 }];
+
+        for (let fi = 0; fi < flightsToRender.length; fi++) {
+            const flight = flightsToRender[fi];
+            const wpStart = fi > 0 ? flight.depWpIndex + 1 : flight.depWpIndex;
+            const wpEnd = flight.destWpIndex;
+
+            for (let wpIdx = wpStart; wpIdx <= wpEnd; wpIdx++) {
+                const wp = this._waypoints[wpIdx];
+                const isDepRow = wpIdx === 0;
+                const segs = (!isDepRow && (wp._segments?.length ?? 0) > 1 && wp.index > 0)
+                    ? wp._segments : [];
+
+                if (segs.length > 1) {
+                    for (let si = 0; si < segs.length; si++) {
+                        expected.push({ wp, seg: segs[si], segIndex: si });
+                    }
+                } else {
+                    expected.push({ wp, seg: null, segIndex: 0 });
+                }
+            }
+        }
+
+        // Bail if row count doesn't match — structure changed, need full rebuild
+        if (rows.length !== expected.length) return false;
+
+        // Patch each row's cells in-place
+        for (let r = 0; r < rows.length; r++) {
+            const tr = rows[r];
+            const { wp, seg, segIndex } = expected[r];
+
+            // Verify row identity matches
+            if (parseInt(tr.dataset.idx) !== wp.index) return false;
+
+            // Update active/passed classes
+            const newCls = wp.active ? 'active' : (wp.passed ? 'passed' : '');
+            const segCls = segIndex > 0 ? 'rt-seg-row' : '';
+            const wantClass = `rt-row ${segCls} ${newCls}`.replace(/\s+/g, ' ').trim();
+            if (tr.className !== wantClass) tr.className = wantClass;
+
+            // Update cell values (skip edit-mode columns since we're never in edit mode here)
+            const cells = tr.children;
+            for (let c = 0; c < columns.length && c < cells.length; c++) {
+                const val = seg
+                    ? this._getCellValue(wp, columns[c].key, seg, segIndex)
+                    : this._getCellValue(wp, columns[c].key);
+                const valStr = String(val);
+                if (cells[c].innerHTML !== valStr) {
+                    cells[c].innerHTML = valStr;
+                }
+            }
+        }
+
+        // Update totals footer
+        const footerCells = this._tableEl.querySelectorAll('tfoot .rt-totals-row td');
+        if (footerCells.length > 0 && this._waypoints.length >= 2) {
+            let totDist = 0, totEte = 0, totFuel = 0;
+            const destIdx = typeof ActiveRoute !== 'undefined' ? ActiveRoute.getDestIndex() : -1;
+            const limitIdx = destIdx >= 0 ? destIdx : this._waypoints.length - 1;
+            for (let i = 0; i <= limitIdx; i++) {
+                const wp = this._waypoints[i];
+                totDist += wp._dist || 0;
+                totEte  += wp._ete  || 0;
+                totFuel += wp._fuel || 0;
+            }
+            const totalLabel = hasMultipleFlights ? 'TRIP' : 'TOTAL';
+            let ci = 0;
+            for (const col of columns) {
+                if (ci >= footerCells.length) break;
+                let val;
+                switch (col.key) {
+                    case 'wpt':  val = `<span class="rt-totals-label">${totalLabel}</span>`; break;
+                    case 'dist': val = `${Math.round(totDist)}nm`; break;
+                    case 'ete':  val = this._formatTime(totEte); break;
+                    case 'fuel': val = totFuel.toFixed(1); break;
+                    default:     val = ''; break;
+                }
+                const valStr = String(val);
+                if (footerCells[ci].innerHTML !== valStr) footerCells[ci].innerHTML = valStr;
+                ci++;
+            }
+        }
+
+        // Scroll active row into view
+        const activeRow = this._tableEl.querySelector('.rt-row.active');
+        if (activeRow) activeRow.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+
+        return true;
     }
 
     /**

--- a/web/cockpit/route-table.js
+++ b/web/cockpit/route-table.js
@@ -1637,7 +1637,15 @@ class RouteTable {
                 this._updateSummary();
             }
         }
-        setTimeout(() => this._map?.invalidateSize(), 300);
+        setTimeout(() => {
+            this._map?.invalidateSize();
+            this._broadcastHeight();
+        }, 300);
+    }
+
+    _broadcastHeight() {
+        const h = this._el ? this._el.offsetHeight : 0;
+        document.documentElement.style.setProperty('--route-table-height', h + 'px');
     }
 
     // ========== Save Route ==========
@@ -1847,6 +1855,62 @@ class RouteTable {
         document.body.appendChild(overlay);
     }
 
+    _confirmNewRoute() {
+        if (this._newConfirmPending) {
+            // Second tap — confirmed
+            this._newConfirmPending = false;
+            clearTimeout(this._newConfirmTimer);
+            this._newBtn.textContent = 'NEW';
+            this._newBtn.style.color = '';
+            this._newBtn.style.borderColor = '';
+            // Clear persisted plan
+            try { localStorage.removeItem('flypi_active_plan'); } catch {}
+            // Open route editor in new-route mode
+            if (typeof app !== 'undefined' && app.routeEditor) {
+                app.routeEditor.startNewRoute();
+            }
+            return;
+        }
+        // First tap — show confirm state
+        this._newConfirmPending = true;
+        this._newBtn.textContent = 'DELETE?';
+        this._newBtn.style.color = '#e53e3e';
+        this._newBtn.style.borderColor = '#e53e3e';
+        // Revert after 3 seconds if not confirmed
+        this._newConfirmTimer = setTimeout(() => {
+            this._newConfirmPending = false;
+            this._newBtn.textContent = 'NEW';
+            this._newBtn.style.color = '';
+            this._newBtn.style.borderColor = '';
+        }, 3000);
+    }
+
+    _reverseRoute() {
+        if (!this._waypoints?.length || this._waypoints.length < 2) {
+            if (typeof app !== 'undefined') app.showToast('Need at least 2 waypoints to reverse', 'amber');
+            return;
+        }
+        const reversed = [...this._waypoints].reverse();
+        const trip = app?._currentTrip || {};
+        const plan = {
+            ...trip,
+            departure: reversed[0]?.icao || '',
+            destination: reversed[reversed.length - 1]?.icao || '',
+            waypoints: reversed,
+            flight_plan: {
+                ...(trip.flight_plan || {}),
+                departure: reversed[0]?.icao || '',
+                destination: reversed[reversed.length - 1]?.icao || '',
+                route: reversed.map(w => w.icao || w.name).filter(Boolean),
+                legs: [],
+            },
+        };
+        if (typeof app !== 'undefined') {
+            app.applyRouteEdit(plan);
+            app.showToast('Route reversed');
+        }
+    }
+
     // ========== DOM ==========
 
     _buildDOM() {
@@ -1859,9 +1923,11 @@ class RouteTable {
         this._handleEl.innerHTML = `
             <span class="handle-grip">\u2261</span>
             <span class="handle-summary"></span>
-            <button class="rt-save-btn" style="display:none">SAVE</button>
+            <button class="rt-save-btn">SAVE</button>
             <button class="rt-load-btn">LOAD</button>
             <button class="rt-upload-btn">UPLOAD</button>
+            <button class="rt-new-btn">NEW</button>
+            <button class="rt-reverse-btn">REV</button>
             <button class="rt-profile-btn" title="Terrain profile" style="min-width:44px;min-height:44px;font-size:18px;background:none;border:none;color:inherit;cursor:pointer;padding:0 8px">\u26F0</button>
             <button class="route-table-edit-btn">EDIT</button>
         `;
@@ -1899,6 +1965,12 @@ class RouteTable {
 
         this._uploadBtn = this._handleEl.querySelector('.rt-upload-btn');
         this._wireButton(this._uploadBtn, () => this._showUploadModal());
+
+        this._newBtn = this._handleEl.querySelector('.rt-new-btn');
+        this._wireButton(this._newBtn, () => this._confirmNewRoute());
+
+        this._reverseBtn = this._handleEl.querySelector('.rt-reverse-btn');
+        this._wireButton(this._reverseBtn, () => this._reverseRoute());
 
         this._profileBtn = this._handleEl.querySelector('.rt-profile-btn');
         this._wireButton(this._profileBtn, () => this._openProfileView());
@@ -2277,6 +2349,7 @@ class RouteTable {
             const delta = startY - clientY;
             const newH = Math.max(0, Math.min(window.innerHeight * 0.6, startH + delta));
             this._bodyEl.style.maxHeight = newH + 'px';
+            this._broadcastHeight();
         };
 
         const onEnd = () => {
@@ -2290,6 +2363,7 @@ class RouteTable {
             this._expanded = h > 20;
             this._el.classList.toggle('route-table-expanded', this._expanded);
             this._map?.invalidateSize();
+            this._broadcastHeight();
         };
 
         const grip = this._handleEl;

--- a/web/cockpit/route-table.js
+++ b/web/cockpit/route-table.js
@@ -2393,11 +2393,12 @@ class RouteTable {
             // Fuel stop row between flights (not after the last flight)
             if (fi < flightsToRender.length - 1) {
                 const nextFlight = flightsToRender[fi + 1];
-                // Label: "⛽ Arrived KFGX — Refuel · Flight 2 continues to KLWA"
-                // This makes clear the DES rows above were the ARRIVAL, and CLB rows
-                // below are the DEPARTURE — the fuel stop is the boundary between them.
+                const stopIdx = nextFlight.depWpIndex;
+                // The DES rows above are the arrival into this stop; CLB rows below are
+                // the departure — this row is the boundary between those two legs.
                 html += `<tr class="rt-fuel-stop-row"><td colspan="${numCols}" class="rt-fuel-stop-cell">`;
-                html += `\u26FD\u2002Arrived ${flight.dest} \u2014 Refuel \u00b7 Flight ${fi + 2} continues to ${nextFlight.dest}`;
+                html += `<span>\u26FD\u2002Arrived ${flight.dest} \u2014 Refuel \u00b7 Flight ${fi + 2} continues to ${nextFlight.dest}</span>`;
+                html += `<button class="rt-delete-btn" data-idx="${stopIdx}" title="Remove fuel stop">\u00d7</button>`;
                 html += `</td></tr>`;
                 // Fuel added row — only shown if pilot explicitly set fuel_add_gal on this waypoint
                 const stopWp = this._waypoints[nextFlight.depWpIndex];

--- a/web/cockpit/route-table.js
+++ b/web/cockpit/route-table.js
@@ -2488,31 +2488,25 @@ class RouteTable {
 
         if (this._editMode) {
             if (segIndex === 0) {
-                const rs = segCount > 1 ? ` rowspan="${segCount}"` : '';
-                row += `<td class="rt-reorder-cell"${rs}>
+                row += `<td class="rt-reorder-cell">
                     <button class="rt-up-btn" data-idx="${wp.index}" ${wp.index === 0 ? 'disabled' : ''}>\u25B2</button>
                     <button class="rt-down-btn" data-idx="${wp.index}" ${wp.index === this._waypoints.length - 1 ? 'disabled' : ''}>\u25BC</button>
                 </td>`;
+            } else {
+                row += '<td></td>';
             }
-            // segIndex > 0: skip reorder cell (covered by rowspan)
         }
 
         for (const col of columns) {
-            // Multi-segment: rowspan wpt/hdg/wind across all SegmentRows for the same Leg
-            if (seg && segCount > 1 && (col.key === 'wpt' || col.key === 'hdg' || col.key === 'brg' || col.key === 'wind')) {
+            if (col.key === 'alt' && this._editMode) {
                 if (segIndex === 0) {
-                    const val = this._getCellValue(wp, col.key, seg, 0);
-                    row += `<td rowspan="${segCount}">${val}</td>`;
+                    // Tappable altitude cell in edit mode
+                    const altVal  = wp.alt ?? wp.altitude ?? '\u2014';
+                    const display = typeof altVal === 'number' ? (altVal >= 1000 ? altVal.toLocaleString() : altVal) : altVal;
+                    row += `<td class="rt-alt-cell" data-idx="${wp.index}">${display} <span class="rt-alt-edit-icon">\u25BE</span></td>`;
+                } else {
+                    row += `<td></td>`;
                 }
-                // segIndex > 0: omit — covered by rowspan
-            } else if (col.key === 'alt' && this._editMode && segIndex === 0) {
-                // Tappable altitude cell in edit mode (issue #31)
-                const altVal  = wp.alt ?? wp.altitude ?? '\u2014';
-                const display = typeof altVal === 'number' ? (altVal >= 1000 ? altVal.toLocaleString() : altVal) : altVal;
-                const rs      = segCount > 1 ? ` rowspan="${segCount}"` : '';
-                row += `<td class="rt-alt-cell" data-idx="${wp.index}"${rs}>${display} <span class="rt-alt-edit-icon">\u25BE</span></td>`;
-            } else if (col.key === 'alt' && this._editMode && segIndex > 0) {
-                // omit — covered by rowspan from segIndex===0
             } else {
                 const val = seg ? this._getCellValue(wp, col.key, seg, segIndex) : this._getCellValue(wp, col.key);
                 row += `<td>${val}</td>`;
@@ -2521,8 +2515,9 @@ class RouteTable {
 
         if (this._editMode) {
             if (segIndex === 0) {
-                const rs = segCount > 1 ? ` rowspan="${segCount}"` : '';
-                row += `<td${rs}><button class="rt-delete-btn" data-idx="${wp.index}">\u00d7</button></td>`;
+                row += `<td><button class="rt-delete-btn" data-idx="${wp.index}">\u00d7</button></td>`;
+            } else {
+                row += '<td></td>';
             }
         }
 

--- a/web/cockpit/route-table.js
+++ b/web/cockpit/route-table.js
@@ -39,6 +39,8 @@ function isFuelStop(wp, index, waypoints) {
     if (index === 0 || index >= waypoints.length - 1) return false;
     // Primary check: type flag set on the waypoint object
     if (wp.type === 'APT') return true;
+    // Non-airport types are never fuel stops
+    if (wp.type === 'VOR' || wp.type === 'NDB' || wp.type === 'FIX' || wp.type === 'GPS' || wp.type === 'WPT') return false;
     // Fallback: plans loaded from legs-only (waypoints:null) don't have type set.
     // Treat any intermediate airport-looking waypoint (4-char K-prefix ICAO) as a
     // potential fuel stop. This handles the common US airport case.
@@ -436,13 +438,18 @@ class RouteTable {
     }
 
     _pushUndo() {
-        this._undoStack.push(JSON.parse(JSON.stringify(this._waypoints)));
+        this._undoStack.push({
+            waypoints: JSON.parse(JSON.stringify(this._waypoints)),
+            activeIndex: this._activeIndex,
+        });
         if (this._undoStack.length > 5) this._undoStack.shift();
     }
 
     _popUndo() {
         if (this._undoStack.length === 0) return;
-        this._waypoints = this._undoStack.pop();
+        const state = this._undoStack.pop();
+        this._waypoints = state.waypoints;
+        this._activeIndex = state.activeIndex;
         this._reindex();
         this._onEdited();
     }
@@ -451,6 +458,10 @@ class RouteTable {
         if (index < 0 || index >= this._waypoints.length) return;
         this._pushUndo();
         this._waypoints.splice(index, 1);
+        // Keep _activeIndex valid after removal
+        if (this._activeIndex >= this._waypoints.length) {
+            this._activeIndex = Math.max(this._waypoints.length - 1, -1);
+        }
         this._reindex();
         this._onEdited();
     }
@@ -600,6 +611,7 @@ class RouteTable {
 
     _moveWaypoint(fromIdx, toIdx) {
         if (fromIdx === toIdx) return;
+        if (fromIdx < 0 || fromIdx >= this._waypoints.length) return;
         if (toIdx < 0 || toIdx >= this._waypoints.length) return;
         this._pushUndo();
         const [wp] = this._waypoints.splice(fromIdx, 1);
@@ -650,13 +662,21 @@ class RouteTable {
         const plan = {
             ...(this._trip || {}),
             // trip.waypoints[] — all waypoints across all flights
-            waypoints: this._waypoints.map(wp => ({
-                icao: wp.icao,
-                name: wp.name,
-                lat: wp.lat,
-                lon: wp.lon,
-                alt: wp.alt ?? wp.altitude,
-            })),
+            waypoints: this._waypoints.map(wp => {
+                const out = {
+                    icao: wp.icao,
+                    name: wp.name,
+                    lat: wp.lat,
+                    lon: wp.lon,
+                    alt: wp.alt ?? wp.altitude,
+                };
+                if (wp.type) out.type = wp.type;
+                if (wp.fuel_add_gal != null) out.fuel_add_gal = wp.fuel_add_gal;
+                if (wp.alt_constraint) out.alt_constraint = wp.alt_constraint;
+                if (wp.alt_constraint_upper != null) out.alt_constraint_upper = wp.alt_constraint_upper;
+                if (wp.elev_ft != null) out.elev_ft = wp.elev_ft;
+                return out;
+            }),
             // trip.flights[] — airport-to-airport Flight segments
             flights: (this._flights || []).map(f => ({
                 dep:  f.dep,
@@ -2398,7 +2418,9 @@ class RouteTable {
                 // the departure — this row is the boundary between those two legs.
                 html += `<tr class="rt-fuel-stop-row"><td colspan="${numCols}" class="rt-fuel-stop-cell">`;
                 html += `<span>\u26FD\u2002Arrived ${flight.dest} \u2014 Refuel \u00b7 Flight ${fi + 2} continues to ${nextFlight.dest}</span>`;
-                html += `<button class="rt-delete-btn" data-idx="${stopIdx}" title="Remove fuel stop">\u00d7</button>`;
+                if (this._editMode) {
+                    html += `<button class="rt-delete-btn" data-idx="${stopIdx}" title="Remove fuel stop">\u00d7</button>`;
+                }
                 html += `</td></tr>`;
                 // Fuel added row — only shown if pilot explicitly set fuel_add_gal on this waypoint
                 const stopWp = this._waypoints[nextFlight.depWpIndex];

--- a/web/cockpit/tab-bar.js
+++ b/web/cockpit/tab-bar.js
@@ -152,6 +152,10 @@ class TabBar {
                 const ip = c.stratuxIp || '192.168.10.1';
                 window.open(`http://${ip}`, '_blank');
             }},
+            { icon: '📶', label: 'FIS-B Status', action: () => {
+                if (c.fisbStatus?.show) c.fisbStatus.show();
+                this._closeMoreDrawer();
+            }},
             { icon: '🗄', label: 'Data Status', action: () => {
                 if (c.dataStatus?.show) c.dataStatus.show();
                 this._closeMoreDrawer();
@@ -582,6 +586,7 @@ class TabBar {
             ['#charts','Approach Charts'],['#weather','Weather'],
             ['#recording','Recording'],['#fuel','Fuel'],
             ['#offline','Offline'],['#config','Config'],
+            ['#releases','Releases'],
         ];
 
         // Pull aircraft config for dynamic values
@@ -871,6 +876,24 @@ class TabBar {
 </ul>
 <p>Aircraft-specific data (V-speeds, fuel calibration, power settings table, engine limits) is in <code>aircraft-config.json</code>. The power settings table in that file is derived from actual ${acTail} flight data — 2,004 data points across 33 flights.</p>
 <p><strong>Stratux IP</strong> — tap the Stratux field to set a custom IP if your network uses a non-default address.</p>
+
+<!-- ═══ RELEASE NOTES ═══ -->
+<h2 id="releases" style="font-size:17px;font-weight:700;margin:24px 0 10px;padding-bottom:6px;border-bottom:1px solid #1a3055;color:#00ff88">Release Notes</h2>
+<div style="background:rgba(0,136,255,0.08);border-left:3px solid #0088ff;padding:8px 12px;border-radius:0 6px 6px 0;margin:10px 0;font-size:13px">
+  <strong>Rollback:</strong> Previous APKs are saved in the repo at each version bump. To roll back during flight: open the Android Files app, navigate to the Downloads or FlyTab folder, and tap the previous APK to install. The app will downgrade in place — your plan, logbook, and settings are preserved in IndexedDB.
+</div>
+<table style="width:100%;border-collapse:collapse;margin:10px 0;font-size:13px">
+  <tr style="background:#152847"><th style="padding:6px 8px;text-align:left;color:#8899aa">Version</th><th style="padding:6px 8px;text-align:left;color:#8899aa">Changes</th></tr>
+  <tr><td style="padding:6px 8px;border-bottom:1px solid #1a3055;white-space:nowrap;vertical-align:top">v4.87</td><td style="padding:6px 8px;border-bottom:1px solid #1a3055">FIS-B Status page — reception health, tower list, product freshness table with route-aware prioritization. Tap FIS-B badge or More → FIS-B Status. Tower polling added to Stratux client.</td></tr>
+  <tr><td style="padding:6px 8px;border-bottom:1px solid #1a3055;white-space:nowrap;vertical-align:top">v4.86</td><td style="padding:6px 8px;border-bottom:1px solid #1a3055">Runway extensions fetch from AWC API (fixes missing rwy ext on map). Airport popup RWY tab populated from AWC. Layer panel accordion max-height fix (Rwy Ext / Show ±ALT toggles no longer clipped).</td></tr>
+  <tr><td style="padding:6px 8px;border-bottom:1px solid #1a3055;white-space:nowrap;vertical-align:top">v4.85</td><td style="padding:6px 8px;border-bottom:1px solid #1a3055">Route editor auto-apply on every edit (add/remove/move/undo). NEW and REV buttons on route table. Airport sidebar no longer overlaps route table. Fuel moved below frequencies in airport INFO tab. SAVE button always visible.</td></tr>
+  <tr><td style="padding:6px 8px;border-bottom:1px solid #1a3055;white-space:nowrap;vertical-align:top">v4.76</td><td style="padding:6px 8px;border-bottom:1px solid #1a3055">Selective live update (only active leg recalcs in flight). NASR coordinate resolution for all waypoint types. Undo depth increased. CRZ/DES segment column alignment fix.</td></tr>
+  <tr><td style="padding:6px 8px;border-bottom:1px solid #1a3055;white-space:nowrap;vertical-align:top">v4.75</td><td style="padding:6px 8px;border-bottom:1px solid #1a3055">Auto GPS fallback to device GPS when Stratux unavailable. Issues #16-19: emergency overlay, NOTAM flood protection, offline route editing, fuel stop delete.</td></tr>
+  <tr><td style="padding:6px 8px;border-bottom:1px solid #1a3055;white-space:nowrap;vertical-align:top">v4.69</td><td style="padding:6px 8px;border-bottom:1px solid #1a3055">Fuel K-factor calculator. Measurement history. EDM fuel persist. Weather dots fix. Radar NO DATA fix. Altimeter hPa/inHg fix. Power tradeoff panel visibility fix.</td></tr>
+  <tr><td style="padding:6px 8px;border-bottom:1px solid #1a3055;white-space:nowrap;vertical-align:top">v4.50</td><td style="padding:6px 8px;border-bottom:1px solid #1a3055">Emergency glide approach guidance with live HDG/DIST/profile. Deep link support. METAR age parsing fix.</td></tr>
+  <tr><td style="padding:6px 8px;border-bottom:1px solid #1a3055;white-space:nowrap;vertical-align:top">v4.46</td><td style="padding:6px 8px;border-bottom:1px solid #1a3055">Route editor overhaul — New Route, Edit Route, APCH labels, save integrity. GPS track recording independent of engine data.</td></tr>
+  <tr><td style="padding:6px 8px;white-space:nowrap;vertical-align:top">v4.42</td><td style="padding:6px 8px">Terrain profile view with SRTM 30m data. Airspace bands in profile. Collision highlighting. Preflight brief package with Claude AI summary.</td></tr>
+</table>
 
 <div style="margin:40px 0 20px;padding-top:16px;border-top:1px solid #1a3055;text-align:center;font-size:12px;color:#8899aa">
   FlyTab ${ver} · ${acTail} ${acType}

--- a/web/index.html
+++ b/web/index.html
@@ -101,6 +101,7 @@
     <script src="./cockpit/approach-charts.js"></script>
     <script src="./cockpit/fisb-nexrad.js"></script>
     <script src="./cockpit/fisb-weather.js"></script>
+    <script src="./cockpit/fisb-status.js"></script>
     <script src="./cockpit/radar-loop.js"></script>
     <script src="./cockpit/lightning.js"></script>
     <script src="./cockpit/ifr-clearance.js"></script>

--- a/web/shared/fisb-client.js
+++ b/web/shared/fisb-client.js
@@ -43,6 +43,8 @@ class FisbClient extends EventTarget {
         this._onFisbFrame = (e) => this._handleFisbFrame(e.detail);
     }
 
+    get nexradBlockCount() { return this._nexradBlocks?.size || 0; }
+
     start() {
         this._stratux.addEventListener('stratux:weather', this._onWeather);
         this._stratux.addEventListener('stratux:nexrad', this._onNexrad);

--- a/web/shared/gps-source.js
+++ b/web/shared/gps-source.js
@@ -141,6 +141,7 @@ class GpsSource {
 
     _onInternalPosition(pos) {
         const c = pos.coords;
+        const M_TO_FT = 3.28084;
 
         // Calculate ground speed in knots (coords.speed is m/s, may be null)
         const speedKt = (c.speed != null && c.speed >= 0) ? c.speed * 1.94384 : 0;
@@ -148,8 +149,11 @@ class GpsSource {
         // Calculate course (coords.heading is degrees, may be null)
         const course = (c.heading != null && !isNaN(c.heading)) ? c.heading : 0;
 
-        // Altitude in feet (coords.altitude is meters MSL, may be null)
-        const altMsl = (c.altitude != null) ? c.altitude * 3.28084 : 0;
+        // Altitude in feet (coords.altitude is meters MSL, may be null).
+        // Use null — not 0 — when altitude is unavailable so consumers that guard
+        // with `!= null` bypass altitude-dependent logic (e.g. traffic filtering)
+        // rather than treating ownship as at sea level.
+        const altMsl = (c.altitude != null) ? c.altitude * M_TO_FT : null;
 
         // Vertical speed — EMA-smoothed to reduce consumer GPS altitude jitter.
         // Raw delta can swing ±2000 fpm from 10-30m jitter at 1Hz.
@@ -158,7 +162,7 @@ class GpsSource {
         if (this._lastInternal && this._lastInternal._rawAltM != null && c.altitude != null) {
             const dt = (now - this._lastInternal.timestamp) / 1000;
             if (dt > 0 && dt < 10) {
-                const rawVs = ((c.altitude - this._lastInternal._rawAltM) * 3.28084 / dt) * 60;
+                const rawVs = ((c.altitude - this._lastInternal._rawAltM) * M_TO_FT / dt) * 60;
                 this._vsSmoothed = 0.3 * rawVs + 0.7 * this._vsSmoothed;
             }
         }

--- a/web/shared/stratux-client.js
+++ b/web/shared/stratux-client.js
@@ -19,6 +19,7 @@ class StratuxClient extends EventTarget {
         this._maxDelay = 30000;
         this._reconnectTimer = null;
         this._statusTimer = null;
+        this._towerTimer = null;
 
         // Traffic map: icao_addr → target object
         this.traffic = new Map();
@@ -26,6 +27,8 @@ class StratuxClient extends EventTarget {
         this.situation = null;
         // Device status from /getStatus
         this.deviceStatus = null;
+        // Tower data from /getTowers
+        this.towerData = {};
 
         this._purgeInterval = null;
 
@@ -48,6 +51,7 @@ class StratuxClient extends EventTarget {
             this._connectWeather();
             this._connectJsonio();
             this._pollStatus();
+            this._pollTowers();
         }
         this._startPurge();
     }
@@ -60,6 +64,7 @@ class StratuxClient extends EventTarget {
         if (this._reconnectTimer) { clearTimeout(this._reconnectTimer); this._reconnectTimer = null; }
         if (this._purgeInterval) { clearInterval(this._purgeInterval); this._purgeInterval = null; }
         if (this._statusTimer) { clearInterval(this._statusTimer); this._statusTimer = null; }
+        if (this._towerTimer) { clearInterval(this._towerTimer); this._towerTimer = null; }
         clearTimeout(this._staleTimer);
         this._staleTimer = null;
         this._stale = false;
@@ -248,6 +253,20 @@ class StratuxClient extends EventTarget {
         };
         poll();
         this._statusTimer = setInterval(poll, 10000);
+    }
+
+    _pollTowers() {
+        const poll = async () => {
+            try {
+                const r = await fetch(`http://${this.ip}/getTowers`, { cache: 'no-store' });
+                if (r.ok) {
+                    this.towerData = await r.json();
+                    this.dispatchEvent(new CustomEvent('stratux:towers', { detail: this.towerData }));
+                }
+            } catch { /* offline */ }
+        };
+        poll();
+        this._towerTimer = setInterval(poll, 10000);
     }
 
     // ========== Weather WebSocket (/weather) ==========

--- a/web/style.css
+++ b/web/style.css
@@ -2223,6 +2223,26 @@ body {
     padding-top: 4px;
 }
 
+.rt-fuel-stop-cell {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 4px 6px 4px 8px;
+    font-size: var(--text-sm);
+    color: var(--text-secondary);
+    background: var(--bg-surface);
+    border-top: 1px solid var(--border);
+    border-bottom: 1px solid var(--border);
+}
+.rt-fuel-added-cell {
+    text-align: center;
+    font-size: var(--text-sm);
+    color: var(--status-ok);
+    padding: 2px 8px 4px;
+    background: var(--bg-surface);
+    border-bottom: 1px solid var(--border);
+}
+
 .route-table-content .rt-totals-label {
     color: var(--text-label);
     font-weight: 700;
@@ -7445,6 +7465,11 @@ body {
     color: var(--text-secondary);
 }
 .ps-error { color: var(--status-danger); }
+
+/* Hide tab bar while emergency overlay is active so ACKNOWLEDGE button is reachable */
+body.emergency-active #tabBar {
+    display: none !important;
+}
 
 /* ── Emergency Glide Overlay (Scenario 6) ───────────────────────────────── */
 .eg-overlay {

--- a/web/style.css
+++ b/web/style.css
@@ -161,6 +161,7 @@
     /* ── Tab bar height — total reserved space at bottom (tab bar + nav bar) ── */
     --tab-bar-height:    calc(72px + var(--android-nav-height));
     --bottom-chrome:     calc(var(--tab-bar-height) + 64px);  /* tab bar + instrument strip */
+    --route-table-height: 0px;
 
     /* ── Touch targets — Apple HIG + sunlight glove tolerance ── */
     --touch-compact:     36px;      /* compact toolbar/table buttons (fixed, no cockpit override) */
@@ -2248,7 +2249,7 @@ body {
     font-weight: 700;
 }
 
-.rt-save-btn, .rt-load-btn, .rt-upload-btn {
+.rt-save-btn, .rt-load-btn, .rt-upload-btn, .rt-new-btn, .rt-reverse-btn {
     padding: 4px 10px;
     border: 1px solid var(--border);
     border-radius: 4px;
@@ -2263,7 +2264,7 @@ body {
     min-height: var(--touch-compact);
     margin-left: 4px;
 }
-.rt-save-btn:active, .rt-load-btn:active, .rt-upload-btn:active {
+.rt-save-btn:active, .rt-load-btn:active, .rt-upload-btn:active, .rt-new-btn:active, .rt-reverse-btn:active {
     background: var(--border);
     color: var(--text-primary);
 }
@@ -3120,6 +3121,235 @@ body {
     padding: 10px 16px 12px;
     background: var(--bg-primary);
     border-top: 1px solid var(--border);
+}
+
+/* ========== FIS-B Status Page ========== */
+
+.fisb-status-page {
+    position: fixed;
+    top: 0; left: 0; right: 0;
+    bottom: var(--tab-bar-height);
+    z-index: 800;
+    background: var(--bg-primary);
+    display: none;
+    flex-direction: column;
+    font-family: var(--font-ui);
+}
+.fisb-status-page.visible {
+    display: flex;
+}
+.fisb-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px 16px;
+    background: var(--bg-surface);
+    border-bottom: 1px solid var(--border);
+    flex-shrink: 0;
+}
+.fisb-title {
+    font-size: 15px;
+    font-weight: 700;
+    letter-spacing: 1px;
+    color: var(--text-primary);
+}
+.fisb-close {
+    background: none;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: var(--text-secondary);
+    font-size: 16px;
+    padding: 4px 10px;
+    cursor: pointer;
+    min-height: 36px;
+}
+.fisb-body {
+    flex: 1;
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+    padding: 8px 12px 20px;
+}
+
+/* Health bar */
+.fisb-health-bar {
+    display: flex;
+    gap: 4px;
+    flex-wrap: wrap;
+    margin-bottom: 12px;
+}
+.fisb-hcell {
+    flex: 1;
+    min-width: 70px;
+    padding: 6px 8px;
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    text-align: center;
+}
+.fisb-hcell-label {
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 1px;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    margin-bottom: 2px;
+}
+.fisb-hcell-value {
+    font-family: var(--font-instrument, monospace);
+    font-size: 16px;
+    font-weight: 700;
+    color: var(--text-primary);
+}
+.fisb-hcell-value.ok   { color: #1e8c3a; }
+.fisb-hcell-value.warn { color: #cc8800; }
+.fisb-hcell-value.bad  { color: #cc2222; }
+
+/* Section labels */
+.fisb-section-label {
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 1.5px;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    margin: 12px 0 6px;
+    padding-bottom: 3px;
+    border-bottom: 1px solid var(--border);
+}
+
+/* Status dots */
+.fisb-dot {
+    display: inline-block;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    vertical-align: middle;
+    margin-right: 4px;
+}
+.fisb-dot.ok   { background: #1e8c3a; }
+.fisb-dot.warn { background: #cc8800; }
+.fisb-dot.bad  { background: #cc2222; }
+.fisb-dot.none { background: #ccc; }
+
+/* Route weather table */
+.fisb-route-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 14px;
+    margin-bottom: 4px;
+}
+.fisb-route-table th {
+    text-align: left;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+    color: var(--text-muted);
+    padding: 4px 8px;
+    border-bottom: 1px solid var(--border);
+}
+.fisb-route-table td {
+    padding: 6px 8px;
+    border-bottom: 1px solid var(--border-light);
+}
+.fisb-route-icao {
+    font-family: var(--font-instrument, monospace);
+    font-weight: 700;
+}
+.fisb-route-row.missing {
+    background: #fff0f0;
+}
+.fisb-route-row.partial {
+    background: #fffaf0;
+}
+
+/* Product table */
+.fisb-product-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 13px;
+}
+.fisb-product-table thead th {
+    text-align: left;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+    color: var(--text-muted);
+    padding: 4px 6px;
+    border-bottom: 1px solid var(--border);
+}
+.fisb-product-table thead th:first-child {
+    width: 16px;
+    padding-right: 0;
+}
+.fisb-product-row td {
+    padding: 6px 6px;
+    border-bottom: 1px solid var(--border-light);
+    vertical-align: top;
+}
+.fisb-product-row.none td {
+    color: var(--text-muted);
+}
+.fisb-product-name {
+    font-weight: 600;
+    white-space: nowrap;
+}
+.fisb-product-count, .fisb-product-age {
+    font-family: var(--font-instrument, monospace);
+    white-space: nowrap;
+    min-width: 36px;
+}
+.fisb-product-stations {
+    line-height: 1.6;
+    word-break: break-word;
+}
+.fisb-station {
+    display: inline-block;
+    font-family: var(--font-instrument, monospace);
+    font-size: 11px;
+    padding: 1px 4px;
+    margin: 1px 2px;
+    background: var(--bg-surface);
+    border: 1px solid var(--border);
+    border-radius: 3px;
+}
+.fisb-station.route {
+    font-weight: 700;
+    border-color: #0066cc;
+    background: #e8f0ff;
+    color: #003d7a;
+}
+.fisb-station-dim {
+    color: var(--text-muted);
+    font-size: 11px;
+}
+
+/* Tower table */
+.fisb-tower-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 13px;
+}
+.fisb-tower-table th {
+    text-align: left;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+    color: var(--text-muted);
+    padding: 4px 8px;
+    border-bottom: 1px solid var(--border);
+}
+.fisb-tower-table td {
+    padding: 5px 8px;
+    border-bottom: 1px solid var(--border-light);
+    font-family: var(--font-instrument, monospace);
+}
+.fisb-tower-sig.ok   { color: #1e8c3a; font-weight: 700; }
+.fisb-tower-sig.warn { color: #cc8800; font-weight: 700; }
+.fisb-tower-sig.bad  { color: #cc2222; font-weight: 700; }
+
+.fisb-no-data {
+    color: var(--text-muted);
+    font-size: 12px;
+    padding: 8px 0;
 }
 
 /* ========== Airport Popup ========== */
@@ -5692,7 +5922,7 @@ body {
 }
 
 .lp-accordion.open .lp-accordion-body {
-    max-height: 600px;
+    max-height: 1200px;
 }
 
 /* ── Weather map labels (ceil / vis / wind) ─────────────────────────────────── */
@@ -5965,13 +6195,13 @@ body {
     position: absolute;
     top: 0;
     right: 0;
-    bottom: 0;
+    bottom: var(--route-table-height);
     width: 300px;
     z-index: 600;
     background: var(--bg-surface);
     border-left: 1px solid var(--border-strong);
     transform: translateX(100%);
-    transition: transform 0.2s ease;
+    transition: transform 0.2s ease, bottom 0.2s ease;
     overflow: hidden;
     display: flex;
     flex-direction: column;

--- a/web/version.json
+++ b/web/version.json
@@ -1,5 +1,0 @@
-{
-  "version": "v4.45",
-  "build": 47,
-  "app": "FlyTab"
-}


### PR DESCRIPTION
## Summary

Fixes four bugs found during the April 10 KAFP→KLKR flight:

- **#16 — GPS altitude null coercion**: `gps-source.js` was returning `0` instead of `null` when the internal GPS had no altitude fix. This caused the traffic altitude filter to treat the aircraft as being at 0 ft MSL, hiding all traffic above 5,000 ft.

- **#17 — Offline route editing silent failure**: The Direct-To and Nearby search catch blocks silently swallowed NASR database errors, leaving the results panel blank with no explanation. Now shows "Airport data unavailable offline".

- **#18 — Emergency overlay ACKNOWLEDGE button hidden**: The tab bar (`z-index: 99999`) covered the ACKNOWLEDGE button in portrait mode. Fixed by toggling `body.emergency-active` when the overlay opens/closes, which hides the tab bar via CSS. Also: `_dismissOverlay` now removes the class unconditionally (before the `if (this._overlay)` guard) to prevent class leak if the overlay is removed externally. Altitude fallback added: `alt_msl ?? alt_baro ?? 0` prevents 0 ft AGL glide calculation when internal GPS has no MSL fix.

- **#18 — NOTAM alert flood**: FIS-B binary-encoded NOTAM-D/FDC frames (product IDs 11/12) have no decoded `Text` field; the `raw = JSON.stringify(msg)` fallback produced Python-style binary strings that fired 20-second toast alerts stacking 8+ banners over the map. Now skips the toast when `notam.plain` is empty.

- **#19 — Fuel stop not deletable**: The fuel stop separator row in the route table had no delete control. Added a `×` button using the existing `.rt-delete-btn` delegated click handler — no new event wiring needed.

## Test plan

- [ ] Confirm ACKNOWLEDGE button is reachable in portrait mode during engine emergency
- [ ] Verify tab bar reappears after dismissing the emergency overlay
- [ ] Fly with FIS-B active and confirm NOTAM alerts only show for decoded text NOTAMs
- [ ] Open route editor offline and confirm "Airport data unavailable offline" message appears in Direct-To and Nearby search
- [ ] Add a fuel stop to a multi-leg route and confirm the × button appears and removes the stop

🤖 Generated with [Claude Code](https://claude.com/claude-code)