### PR TITLE
fix: add updateWhenZooming to NEXRAD tile layers (#48)

### DIFF
--- a/web/cockpit/map.js
+++ b/web/cockpit/map.js
@@ -73,6 +73,7 @@ class InetRadarSource {
             const layer = L.tileLayer(url, {
                 opacity: 0,
                 maxZoom: 14,
+                updateWhenZooming: false,
                 attribution: 'NEXRAD © Iowa State Mesonet',
             });
             layer.addTo(this._map);
@@ -606,6 +607,7 @@ class CockpitMap {
                 {
                     opacity: fisbActive ? 0.3 : (Settings.radarOpacity || 0.5),
                     maxZoom: 14,
+                    updateWhenZooming: false,
                     attribution: 'NEXRAD © Iowa State Mesonet',
                 }
             );


### PR DESCRIPTION
## Summary

- Adds `updateWhenZooming: false` to the live NEXRAD radar tile layer and all 12 historical radar loop frames
- Prevents zoom-transition seam artifact (old CSS-scaled tiles visible alongside newly-loading tiles during zoom)
- Matches the option already set on all three FAA tile layers (sectional, IFR, TAC)

## Changes

`web/cockpit/map.js` — two lines added, zero changed, zero removed:
- Line 76: `InetRadarSource._buildLayers()` historical frames
- Line 610: `CockpitMap.toggleRadar()` live radar layer

## Verification

- Iowa State Mesonet serves tiles at all zoom levels (z0-z16+), so no `minNativeZoom`/`maxNativeZoom` bounds are needed
- `updateWhenZooming: false` only affects *when* tiles load during zoom animation — no change to tile URLs, opacity, z-index, or any other behavior
- Radar loop playback, opacity control, and FIS-B/internet source switching are unaffected

## Test plan

- [ ] Toggle radar on, zoom in/out — no tile seam during zoom transition
- [ ] Start radar loop playback — frames animate correctly
- [ ] Toggle radar off and on — layer cleanup and re-creation work

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)