### PR TITLE
fix: map display correctness — labels, z-index, animation, radar scoping

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,7 @@
  * Android Capacitor cockpit app. All data local. Pi for live telemetry only.
  */
 
-const FLYTAB_VERSION = 'v5.03';
+const FLYTAB_VERSION = 'v5.12';
 
 // ========== Diagnostic Logger (ring buffer in localStorage) ==========
 const DiagLog = (() => {

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,7 @@
  * Android Capacitor cockpit app. All data local. Pi for live telemetry only.
  */
 
-const FLYTAB_VERSION = 'v5.12';
+const FLYTAB_VERSION = 'v5.13';
 
 // ========== Diagnostic Logger (ring buffer in localStorage) ==========
 const DiagLog = (() => {

--- a/web/app.js
+++ b/web/app.js
@@ -802,6 +802,7 @@ class FlyTabApp {
                 airportPopup: this.airportPopup,
                 stratuxIp: Settings.stratuxIp || '192.168.10.1',
                 planSync: this.planSync,
+                radarLoop: this.radarLoop,
             });
             this.tabBar.init();
         }

--- a/web/cockpit/emergency-glide.js
+++ b/web/cockpit/emergency-glide.js
@@ -567,7 +567,7 @@ class EmergencyGlide {
                     paddingTopLeft:     [60, overlayH + 40],
                     paddingBottomRight: [60, 70],
                     maxZoom: 11,
-                    animate: true,
+                    animate: false,
                 }
             );
         } catch (_) {}

--- a/web/cockpit/map.js
+++ b/web/cockpit/map.js
@@ -539,7 +539,7 @@ class CockpitMap {
             iconAnchor: [size / 2, size / 2],
         });
 
-        const marker = L.marker([pirep.lat, pirep.lon], { icon, zIndexOffset: 500 });
+        const marker = L.marker([pirep.lat, pirep.lon], { icon, zIndexOffset: 400 });
 
         // Popup
         const typeLabel = pirep.type === 'turbulence' ? 'TURB'

--- a/web/cockpit/map.js
+++ b/web/cockpit/map.js
@@ -977,6 +977,8 @@ class CockpitMap {
     setRoute(waypoints) {
         if (this.routeLayer && this.map.hasLayer(this.routeLayer)) { this.map.removeLayer(this.routeLayer); }
         if (this._activeLegLine && this.map.hasLayer(this._activeLegLine)) { this.map.removeLayer(this._activeLegLine); this._activeLegLine = null; }
+        if (this._wpZoomHandler) { this.map.off('zoomend', this._wpZoomHandler); this._wpZoomHandler = null; }
+        this._wpMarkers = [];
         this._legLines = [];
         this._routeWaypoints = waypoints || [];
         this._activeWpIdx = 0;
@@ -1005,10 +1007,13 @@ class CockpitMap {
         }
 
         // Waypoint markers — larger radius, tappable for airport popup
+        this._wpMarkers = [];
+        const wpLabelZoom = 8;
+        const showWpLabels = this.map.getZoom() >= wpLabelZoom;
         waypoints.forEach(wp => {
             const marker = L.circleMarker([wp.lat, wp.lon], {
                 radius: 8, color: '#ff44ff', fillColor: '#ff44ff', fillOpacity: 0.8, weight: 2,
-            }).bindTooltip(wp.icao || wp.name || '', { permanent: true, direction: 'top', className: 'wp-label' })
+            }).bindTooltip(wp.icao || wp.name || '', { permanent: showWpLabels, direction: 'top', className: 'wp-label' })
               .addTo(this.routeLayer);
 
             marker.on('click', () => {
@@ -1016,7 +1021,23 @@ class CockpitMap {
                     this._airportPopup.showForAirport(wp.icao, [wp.lat, wp.lon]);
                 }
             });
+            marker._wpLabel = wp.icao || wp.name || '';
+            this._wpMarkers.push(marker);
         });
+
+        // Toggle waypoint label permanence on zoom (hide at overview, show at detail)
+        if (this._wpZoomHandler) this.map.off('zoomend', this._wpZoomHandler);
+        this._wpZoomHandler = () => {
+            const show = this.map.getZoom() >= wpLabelZoom;
+            for (const m of this._wpMarkers) {
+                const tip = m.getTooltip();
+                if (tip && tip.options.permanent !== show) {
+                    m.unbindTooltip();
+                    m.bindTooltip(m._wpLabel, { permanent: show, direction: 'top', className: 'wp-label' });
+                }
+            }
+        };
+        this.map.on('zoomend', this._wpZoomHandler);
 
         this.routeLayer.addTo(this.map);
         this.map.fitBounds(L.latLngBounds(latlngs).pad(0.1));

--- a/web/cockpit/tab-bar.js
+++ b/web/cockpit/tab-bar.js
@@ -69,6 +69,16 @@ class TabBar {
         if (c.planSync?.hide) c.planSync.hide();
         if (c.airportPopup?.close) c.airportPopup.close();
 
+        // Hide radar loop controls when leaving map — they bleed through
+        // full-screen panels in Android WebView despite lower z-index.
+        if (c.radarLoop?._active) {
+            if (tabId === 'map') {
+                c.radarLoop._showControls();
+            } else {
+                c.radarLoop._hideControls();
+            }
+        }
+
         if (tabId === 'tmr') {
             // Timer is a floating popup — toggle without closing other views
             this._toggleTimer();

--- a/web/cockpit/tab-bar.js
+++ b/web/cockpit/tab-bar.js
@@ -71,12 +71,10 @@ class TabBar {
 
         // Hide radar loop controls when leaving map — they bleed through
         // full-screen panels in Android WebView despite lower z-index.
-        if (c.radarLoop?._active) {
-            if (tabId === 'map') {
-                c.radarLoop._showControls();
-            } else {
-                c.radarLoop._hideControls();
-            }
+        if (tabId !== 'map' && tabId !== 'tmr' && tabId !== 'more') {
+            this._hideRadarControls();
+        } else if (tabId === 'map') {
+            this._restoreRadarControls();
         }
 
         if (tabId === 'tmr') {
@@ -132,18 +130,22 @@ class TabBar {
             }},
             { icon: '✈', label: 'Load Plan', action: () => {
                 if (c.planSync?.show) c.planSync.show();
+                this._hideRadarControls();
                 this._closeMoreDrawer();
             }},
             { icon: '🧠', label: 'Engine ML', action: () => {
                 this._closeMoreDrawer();
+                this._hideRadarControls();
                 this._showMLMonitor();
             }},
             { icon: '📋', label: 'Logbook', action: () => {
                 if (c.logbook?.show) c.logbook.show();
+                this._hideRadarControls();
                 this._closeMoreDrawer();
             }},
             { icon: '⛅', label: 'Weather Briefing', action: () => {
                 if (c.wxBriefing?.show) c.wxBriefing.show();
+                this._hideRadarControls();
                 this._closeMoreDrawer();
             }},
             { icon: '📊', label: 'Approach Charts', action: () => {
@@ -152,10 +154,12 @@ class TabBar {
                         ? c.approachCharts._showPlate(c.approachCharts._plateIdx)
                         : c.approachCharts.showForRoute();
                 }
+                this._hideRadarControls();
                 this._closeMoreDrawer();
             }},
             { icon: '⛽', label: 'Fuel Entry', action: () => {
                 if (c.fuelOverlay?.show) c.fuelOverlay.show();
+                this._hideRadarControls();
                 this._closeMoreDrawer();
             }},
             { icon: '📡', label: 'Stratux Status', action: () => {
@@ -164,14 +168,17 @@ class TabBar {
             }},
             { icon: '📶', label: 'FIS-B Status', action: () => {
                 if (c.fisbStatus?.show) c.fisbStatus.show();
+                this._hideRadarControls();
                 this._closeMoreDrawer();
             }},
             { icon: '🗄', label: 'Data Status', action: () => {
                 if (c.dataStatus?.show) c.dataStatus.show();
+                this._hideRadarControls();
                 this._closeMoreDrawer();
             }},
             { icon: '⚙', label: 'Configuration', action: () => {
                 if (c.configEditor?.show) c.configEditor.show();
+                this._hideRadarControls();
                 this._closeMoreDrawer();
             }},
             { icon: '🗺', label: () => {
@@ -209,6 +216,7 @@ class TabBar {
             }},
             { icon: '❓', label: 'Help', action: () => {
                 this._closeMoreDrawer();
+                this._hideRadarControls();
                 this._showHelp();
             }},
         ];
@@ -280,6 +288,18 @@ class TabBar {
             this._tabBar.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
             this._tabBar.querySelector('[data-tab="map"]')?.classList.add('active');
         }
+    }
+
+    // ========== Radar Loop Visibility ==========
+
+    _hideRadarControls() {
+        const rl = this._comps.radarLoop;
+        if (rl?._active) rl._hideControls();
+    }
+
+    _restoreRadarControls() {
+        const rl = this._comps.radarLoop;
+        if (rl?._active) rl._showControls();
     }
 
     // ========== ML Monitor ==========


### PR DESCRIPTION
## Summary

Four independent map display fixes, one commit each for independent revert:

- **#54** PIREP z-index 500→400 so traffic (safety-of-flight) always renders on top of PIREPs (advisory)
- **#51** Emergency glide `fitBounds` — `animate: false` for instant visibility during engine-out
- **#50** Route waypoint labels — zoom-based toggle (permanent at z8+, hover-only below z8) matching the existing airport/navaid/fix pattern
- **#58** Radar loop controls hidden when switching away from map tab — prevents bleed-through on Android WebView

## Files changed

| File | Changes |
|------|---------|
| `web/cockpit/map.js` | PIREP z-index, waypoint label zoom toggle + cleanup |
| `web/cockpit/emergency-glide.js` | `animate: true` → `animate: false` |
| `web/cockpit/tab-bar.js` | Hide/restore radar loop controls on page switch |
| `web/app.js` | Wire `radarLoop` into tab-bar components |

## Test plan

- [ ] Set a route with 3+ waypoints — zoom out to z6, labels should be hover-only; zoom to z8+, labels become permanent
- [ ] Clear route and set a new one — no stale zoom handlers
- [ ] Toggle radar loop on, switch to engine page — loop controls should NOT be visible
- [ ] Switch back to map tab — loop controls should reappear and loop still playing
- [ ] Verify traffic markers render on top of PIREP markers when overlapping
- [ ] Trigger emergency glide (if testable) — map should snap to glide view instantly, no animation

Closes #50, closes #51, closes #54, closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)