### PR TITLE
feat: ForeFlight-style map features — METAR colors, airport rings, track vector, baro strip (v5.14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,64 @@
+# FlyTab Changelog
+
+---
+
+## v5.14 — 2026-04-16
+
+### ForeFlight-style map and instrument improvements
+
+**METAR flight category colors on airport icons (#34)**
+Airport dots are now colored by current flight condition: green (VFR), blue (MVFR), red (IFR), purple (LIFR). Uses FIS-B live data in flight; falls back to internet-fetched METARs when FIS-B is unavailable. No METAR = neutral base icon.
+
+**Towered vs non-towered airport icon style (#35)**
+Towered airports show a solid ring; non-towered airports show a dashed ring. Matches the ForeFlight convention and makes class D/E field distinctions visible at a glance.
+
+**Track vector — 3-minute lookahead (#37)**
+A white vector line extends from ownship in the direction of current track, scaled to 3 minutes of flight at current ground speed. Only visible when GS > 10 kts. Gives a quick sense of where you'll be relative to traffic and airspace.
+
+**Nearest baro station in instrument strip (#40)**
+New `baro` field in the instrument strip shows the altimeter setting from the nearest airport with a METAR. The label updates to the station ICAO (e.g. `KLKR`). Recalculates every 30 seconds or after moving more than 1 NM.
+
+**Config cache fix**
+`cockpit-config.json` is now fetched with `cache: reload` so APK updates always apply the new config rather than serving a stale HTTP-cached version.
+
+---
+
+## v5.13 — 2026-04-15
+
+### Map display correctness (Leaflet audit PRs #59, #60)
+
+- NEXRAD tiles now use `updateWhenZooming: false` to prevent rendering artifacts during zoom (#48)
+- Route waypoint labels suppress below zoom 9 to reduce clutter (#50)
+- Emergency glide circle animation disabled (`animate: false`) to prevent WebView jank (#51)
+- PIREP markers moved to z-index 400 (below traffic at 500) (#54)
+- Radar loop scoped to map page only — no longer runs in background on other tabs (#58)
+
+---
+
+## v5.03 — 2026-04-14
+
+- Waypoint distance and descent rate columns in route table
+- Engine chart sizing improvements
+- Route summary bar packed with trip data and live fuel@dest
+
+---
+
+## v5.02 — 2026-04-13
+
+- Route summary bar with trip totals and live fuel-at-destination
+- Wind correction angle and HDG in route table
+
+---
+
+## v5.01 — 2026-04-12
+
+- Route display and route editor separation (display-only vs edit mode)
+
+---
+
+## v5.00 — 2026-04-11
+
+- Route nav strip with next waypoint, bearing, distance
+- ADS-B display fix
+- Config persistence via separate localStorage key
+- Airport sidebar fixes

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "app.flywhere.flytab"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 503
-        versionName "5.03"
+        versionCode 514
+        versionName "5.14"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/tools/mock-stratux.py
+++ b/tools/mock-stratux.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""
+Mock Stratux WebSocket server for FlyTab ADS-B display testing.
+Serves /traffic, /situation, /weather, /jsonio on a configurable port.
+
+Usage:
+    python3 tools/mock-stratux.py [--port PORT] [--lat LAT] [--lon LON]
+
+Default port: 5678 (matches cockpit-config.json simBridgePort default)
+Default position: 35.0, -80.0 (KLKR area)
+
+Setup in cockpit-config.json:
+    "simMode": true,
+    "simBridgeIp": "localhost",   (or dev machine LAN IP for tablet testing)
+    "simBridgePort": 5678
+
+Then reload the app — it will connect to this server instead of Stratux.
+"""
+
+import asyncio
+import json
+import math
+import time
+import argparse
+import websockets
+import websockets.server
+
+# ---------------------------------------------------------------------------
+# Ownship state — moves east at 150 kts
+# ---------------------------------------------------------------------------
+OWN_LAT   = 35.0
+OWN_LON   = -80.0
+OWN_ALT   = 5000    # ft MSL
+OWN_SPEED = 150     # kts
+OWN_TRACK = 90      # degrees true
+
+# ---------------------------------------------------------------------------
+# Static traffic catalog — positions are lat/lon offsets from ownship origin.
+# Planes move based on their track/speed each update tick.
+# ---------------------------------------------------------------------------
+# 1 deg lat  ≈ 60 NM
+# 1 deg lon  ≈ 60 * cos(35°) ≈ 49 NM  →  1 NM ≈ 0.0204°
+
+_TRAFFIC_INIT = [
+    # Normal white targets — well separated
+    {"icao": 0xABC001, "tail": "N123AB", "dlat":  0.25,  "dlon":  0.0,   "alt": 3500, "track": 270, "speed": 120, "vvel":    0},
+    {"icao": 0xABC002, "tail": "N456CD", "dlat":  0.0,   "dlon":  0.40,  "alt": 6500, "track": 180, "speed": 200, "vvel": -500},
+    {"icao": 0xABC003, "tail": "N789EF", "dlat": -0.15,  "dlon":  0.15,  "alt": 4800, "track":  45, "speed": 140, "vvel":  200},
+    {"icao": 0xABC004, "tail": "N012GH", "dlat": -0.35,  "dlon":  0.0,   "alt": 2500, "track":   0, "speed":  90, "vvel":    0},
+    {"icao": 0xABC005, "tail": "N345IJ", "dlat":  0.0,   "dlon": -0.30,  "alt": 5500, "track":  90, "speed": 175, "vvel":    0},
+    # Yellow caution — within ~3 NM, within 1000 ft
+    {"icao": 0xABC006, "tail": "N678KL", "dlat":  0.035, "dlon":  0.035, "alt": 5200, "track": 225, "speed": 160, "vvel":    0},
+    # Red proximate — within ~1 NM, within 500 ft
+    {"icao": 0xABC007, "tail": "N999TH", "dlat":  0.008, "dlon":  0.012, "alt": 4900, "track": 270, "speed": 150, "vvel":    0},
+]
+
+# Runtime state — lat/lon updated each tick
+_traffic = [dict(t) for t in _TRAFFIC_INIT]
+for t in _traffic:
+    t["lat"] = OWN_LAT + t["dlat"]
+    t["lon"] = OWN_LON + t["dlon"]
+
+_start_time = time.time()
+
+# Connected client sets for each endpoint
+_traffic_clients   = set()
+_situation_clients = set()
+_weather_clients   = set()
+_jsonio_clients    = set()
+
+
+def _elapsed():
+    return time.time() - _start_time
+
+
+def _ownship_pos():
+    """Ownship drifts east over time."""
+    t = _elapsed()
+    # 150 kts east = ~0.00051 deg lon/sec at 35°N
+    lon_rate = (OWN_SPEED / 3600.0) / 49.0   # deg/sec
+    return OWN_LAT, OWN_LON + t * lon_rate
+
+
+def _situation_msg():
+    lat, lon = _ownship_pos()
+    return {
+        "GPSLatitude":          lat,
+        "GPSLongitude":         lon,
+        "GPSAltitudeMSL":       float(OWN_ALT),
+        "BaroPressureAltitude": float(OWN_ALT - 50),
+        "GPSGroundSpeed":       float(OWN_SPEED),
+        "GPSTrueCourse":        float(OWN_TRACK),
+        "GPSVerticalSpeed":     0.0,
+        "GPSFixQuality":        2,
+        "GPSSatellites":        9,
+        "GPSSatellitesSeen":    11,
+        "AHRSPitch":            1.5,
+        "AHRSRoll":             0.5,
+        "AHRSGLoad":            1.0,
+        "AHRSGLoadMin":         0.98,
+        "AHRSGLoadMax":         1.02,
+    }
+
+
+def _update_traffic():
+    """Advance each traffic target by one 2-second tick."""
+    dt = 2.0   # seconds per update
+    for t in _traffic:
+        # Convert speed (kts) + track (deg) to lat/lon deltas
+        track_rad = math.radians(t["track"])
+        nm_per_sec = t["speed"] / 3600.0
+        dlat = math.cos(track_rad) * nm_per_sec * dt / 60.0
+        dlon = math.sin(track_rad) * nm_per_sec * dt / (60.0 * math.cos(math.radians(t["lat"])))
+        t["lat"] += dlat
+        t["lon"] += dlon
+        t["alt"] += t["vvel"] * dt / 60.0
+
+
+def _traffic_msgs():
+    msgs = []
+    for t in _traffic:
+        msgs.append({
+            "Icao_addr":            t["icao"],
+            "Tail":                 t["tail"],
+            "Lat":                  round(t["lat"], 6),
+            "Lng":                  round(t["lon"], 6),
+            "Alt":                  int(t["alt"]),
+            "Track":                t["track"],
+            "Speed":                t["speed"],
+            "Vvel":                 t["vvel"],
+            "Squawk":               "1200",
+            "OnGround":             False,
+            "Age":                  0.0,
+            "ExtrapolatedPosition": False,
+            "SignalLevel":          -45.0,
+            "TargetType":           1,
+        })
+    return msgs
+
+
+async def _broadcast(clients, payload):
+    if not clients:
+        return
+    text = json.dumps(payload)
+    dead = set()
+    for ws in list(clients):
+        try:
+            await ws.send(text)
+        except Exception:
+            dead.add(ws)
+    clients -= dead
+
+
+async def _traffic_loop():
+    while True:
+        _update_traffic()
+        for msg in _traffic_msgs():
+            await _broadcast(_traffic_clients, msg)
+        await asyncio.sleep(2.0)
+
+
+async def _situation_loop():
+    while True:
+        await _broadcast(_situation_clients, _situation_msg())
+        await asyncio.sleep(1.0)
+
+
+async def handler(websocket):
+    try:
+        path = websocket.request.path
+    except AttributeError:
+        path = getattr(websocket, "path", "/")
+
+    if path == "/traffic":
+        _traffic_clients.add(websocket)
+        print(f"  [+] traffic client  ({len(_traffic_clients)} connected)")
+        try:
+            await websocket.wait_closed()
+        finally:
+            _traffic_clients.discard(websocket)
+            print(f"  [-] traffic client  ({len(_traffic_clients)} connected)")
+
+    elif path == "/situation":
+        _situation_clients.add(websocket)
+        print(f"  [+] situation client ({len(_situation_clients)} connected)")
+        try:
+            await websocket.wait_closed()
+        finally:
+            _situation_clients.discard(websocket)
+            print(f"  [-] situation client ({len(_situation_clients)} connected)")
+
+    elif path == "/weather":
+        _weather_clients.add(websocket)
+        try:
+            await websocket.wait_closed()
+        finally:
+            _weather_clients.discard(websocket)
+
+    elif path == "/jsonio":
+        _jsonio_clients.add(websocket)
+        try:
+            await websocket.wait_closed()
+        finally:
+            _jsonio_clients.discard(websocket)
+
+    else:
+        await websocket.close(1008, f"unknown path: {path}")
+
+
+async def main(host, port):
+    print(f"Mock Stratux  →  ws://{host}:{port}")
+    print(f"  Ownship: {OWN_LAT}°N {abs(OWN_LON)}°W  {OWN_ALT} ft  {OWN_TRACK}°  {OWN_SPEED} kts")
+    print(f"  Traffic: {len(_traffic)} targets  (2 normal, 1 caution, 1 proximate + {len(_traffic)-4} more)")
+    print()
+    print("cockpit-config.json:")
+    print('  "simMode": true,')
+    print(f'  "simBridgeIp": "localhost",')
+    print(f'  "simBridgePort": {port}')
+    print()
+
+    async with websockets.serve(handler, host, port):
+        await asyncio.gather(
+            _traffic_loop(),
+            _situation_loop(),
+        )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Mock Stratux WebSocket server")
+    parser.add_argument("--host", default="0.0.0.0", help="Bind host (default: 0.0.0.0)")
+    parser.add_argument("--port", type=int, default=5678, help="Port (default: 5678)")
+    parser.add_argument("--lat",  type=float, default=OWN_LAT)
+    parser.add_argument("--lon",  type=float, default=OWN_LON)
+    args = parser.parse_args()
+
+    OWN_LAT = args.lat
+    OWN_LON = args.lon
+
+    try:
+        asyncio.run(main(args.host, args.port))
+    except KeyboardInterrupt:
+        print("\nStopped.")

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,7 @@
  * Android Capacitor cockpit app. All data local. Pi for live telemetry only.
  */
 
-const FLYTAB_VERSION = 'v5.13';
+const FLYTAB_VERSION = 'v5.14';
 
 // ========== Diagnostic Logger (ring buffer in localStorage) ==========
 const DiagLog = (() => {
@@ -757,6 +757,7 @@ class FlyTabApp {
             this.instrumentStrip = new InstrumentStrip(this.stratuxClient, this.engineClient);
             if (this.fuelOverlay) this.instrumentStrip.setFuelOverlay(this.fuelOverlay);
             if (this.powerTradeoff) this.instrumentStrip.setPowerTradeoff(this.powerTradeoff);
+            if (this.vectorLayers) this.instrumentStrip.setVectorLayers(this.vectorLayers);
             const stripEl = this.instrumentStrip.init();
             // Place instrument strip inside route-table-sheet (after handle) so they stack together
             const rtSheet = document.querySelector('.route-table-sheet');

--- a/web/cockpit-config.json
+++ b/web/cockpit-config.json
@@ -51,7 +51,7 @@
     "fields": ["next", "dest"]
   },
   "instrumentStrip": {
-    "fields": ["gs", "alt", "hdg", "fuel", "dest", "ete"]
+    "fields": ["gs", "alt", "baro", "hdg", "fuel", "dest", "ete"]
   },
   "engineOverlay": {
     "enabled": true,

--- a/web/cockpit/instrument-strip.js
+++ b/web/cockpit/instrument-strip.js
@@ -22,6 +22,11 @@ class InstrumentStrip {
 
         // Last leg update from route-table
         this._legData = null;
+
+        // VectorMapLayers reference for nearest-baro lookup
+        this._vectorLayers = null;
+        this._baroLastPos = null;
+        this._baroLastTime = 0;
     }
 
     /** Wire the fuel field tap to open the fuel overlay. */
@@ -32,6 +37,11 @@ class InstrumentStrip {
     /** Wire the power tradeoff panel (tapping ETE▲ / FUEL▲ opens it). */
     setPowerTradeoff(panel) {
         this._powerTradeoff = panel;
+    }
+
+    /** Wire VectorMapLayers for nearest-baro airport lookup. */
+    setVectorLayers(vl) {
+        this._vectorLayers = vl;
     }
 
     init() {
@@ -130,6 +140,7 @@ class InstrumentStrip {
             dist: { label: 'DIST', unit: 'nm'  },
             dest: { label: 'DEST', unit: 'nm'  },
             ete:  { label: 'ETE',  unit: ''    },
+            baro: { label: 'BARO', unit: '"'   },
         };
 
         const cfg = configs[field] || { label: field.toUpperCase(), unit: '' };
@@ -163,6 +174,7 @@ class InstrumentStrip {
         // Cache references for fast updates
         this._els[field] = valueEl;
         if (deltaEl) this._els[`${field}_delta`] = deltaEl;
+        if (field === 'baro') this._els['baro_label'] = labelEl;
 
         // FUEL field — tap opens fuel overlay
         if (field === 'fuel') {
@@ -206,6 +218,10 @@ class InstrumentStrip {
 
         this._set('gs',  gs  != null ? Math.round(gs)  : '—');
         this._set('alt', alt != null ? Math.round(alt).toLocaleString() : '—');
+
+        if (this._fields.includes('baro') && gpsOk && sit.lat && sit.lon) {
+            this._updateBaro(sit.lat, sit.lon);
+        }
 
         this._updateFuel();
 
@@ -269,6 +285,38 @@ class InstrumentStrip {
             } else {
                 fuelDeltaEl.textContent = '';
             }
+        }
+    }
+
+    _updateBaro(lat, lon) {
+        const now = Date.now();
+        // Throttle: recalculate only every 30s or after moving > 1 NM
+        const movedNm = this._baroLastPos
+            ? CockpitMap._distNm(lat, lon, this._baroLastPos[0], this._baroLastPos[1])
+            : Infinity;
+        if (now - this._baroLastTime < 30000 && movedNm < 1) return;
+        this._baroLastTime = now;
+        this._baroLastPos = [lat, lon];
+
+        if (!this._vectorLayers) return;
+
+        let bestIcao = null, bestDist = Infinity;
+        for (const [icao, pos] of this._vectorLayers._aptPositions) {
+            const entry = this._vectorLayers._getMetarEntry(icao);
+            if (!entry?.decoded?.altimeter) continue;
+            const d = CockpitMap._distNm(lat, lon, pos.lat, pos.lon);
+            if (d < bestDist) { bestDist = d; bestIcao = icao; }
+        }
+
+        if (bestIcao) {
+            const alt = this._vectorLayers._getMetarEntry(bestIcao).decoded.altimeter;
+            this._set('baro', alt.toFixed(2));
+            const labelEl = this._els['baro_label'];
+            if (labelEl) labelEl.textContent = bestIcao;
+        } else {
+            this._set('baro', '—');
+            const labelEl = this._els['baro_label'];
+            if (labelEl) labelEl.textContent = 'BARO';
         }
     }
 

--- a/web/cockpit/map.js
+++ b/web/cockpit/map.js
@@ -681,6 +681,22 @@ class CockpitMap {
             this.map.panTo(pos, { animate: !isFirstFix, duration: 0.5 });
         }
 
+        // Track vector — 3-minute lookahead line, only when airborne
+        if (sit.ground_speed >= 10 && sit.true_course != null) {
+            const nm = sit.ground_speed * 3 / 60;
+            const end = CockpitMap._destPoint(sit.lat, sit.lon, sit.true_course, nm);
+            if (!this._trackVector) {
+                this._trackVector = L.polyline([pos, end], {
+                    color: '#ffffff', weight: 2, opacity: 0.6, interactive: false,
+                }).addTo(this.map);
+            } else {
+                this._trackVector.setLatLngs([pos, end]);
+                if (this._trackVector.options.opacity !== 0.6) this._trackVector.setStyle({ opacity: 0.6 });
+            }
+        } else if (this._trackVector) {
+            this._trackVector.setStyle({ opacity: 0 });
+        }
+
         // Range rings
         this._updateRangeRings(pos);
 
@@ -1511,6 +1527,14 @@ class CockpitMap {
     }
 
     // ========== Geo Utilities ==========
+
+    static _destPoint(lat, lon, bearingDeg, nm) {
+        const R = 3440.065;
+        const brng = bearingDeg * Math.PI / 180;
+        const lat2 = lat + (nm / R) * Math.cos(brng) * (180 / Math.PI);
+        const lon2 = lon + (nm / R) * Math.sin(brng) * (180 / Math.PI) / Math.cos(lat * Math.PI / 180);
+        return [lat2, lon2];
+    }
 
     static _distNm(lat1, lon1, lat2, lon2) {
         const R = 3440.065; // NM

--- a/web/cockpit/vector-map-layers.js
+++ b/web/cockpit/vector-map-layers.js
@@ -364,10 +364,10 @@ class VectorMapLayers {
     /** Map flight category to hex color. */
     _catColor(cat) {
         switch (cat) {
-            case 'VFR':  return '#00ff88';
-            case 'MVFR': return '#00aaff';
-            case 'IFR':  return '#ff4444';
-            case 'LIFR': return '#ff44ff';
+            case 'VFR':  return '#1e8f3c';
+            case 'MVFR': return '#0066cc';
+            case 'IFR':  return '#d92b22';
+            case 'LIFR': return '#8e2cb5';
             default:     return null;
         }
     }
@@ -1001,18 +1001,18 @@ class VectorMapLayers {
                 }
 
                 const towered = apt.tower;
-                // Neutral white/gray base — flight category dot overlays with category color.
-                // Size (7 vs 5) distinguishes towered from non-towered when no weather is known.
-                const baseColor = towered ? '#ffffff' : '#aaaaaa';
+                // Towered: solid ring. Non-towered: dashed ring (ForeFlight convention).
+                // Flight category dot overlays with color when METAR is available.
                 const radius = towered ? 7 : 5;
 
                 // Use default SVG renderer (not canvas) so click events work reliably
                 const marker = L.circleMarker([apt.lat, apt.lon], {
                     radius,
-                    color: '#333333',
-                    fillColor: baseColor,
-                    fillOpacity: 0.9,
-                    weight: 1,
+                    color: towered ? '#ffffff' : '#aaaaaa',
+                    weight: towered ? 1.5 : 1,
+                    dashArray: towered ? null : '4,3',
+                    fillColor: towered ? '#ffffff' : '#888888',
+                    fillOpacity: 0.15,
                     interactive: true,
                     bubblingMouseEvents: false,
                 });

--- a/web/shared/cockpit-config.js
+++ b/web/shared/cockpit-config.js
@@ -218,7 +218,7 @@ class CockpitConfig {
     static async _fetchJson(url) {
         const cacheKey = 'flypi_cfg_' + url.replace(/[^a-z0-9]/gi, '_');
         try {
-            const resp = await fetch(url, { signal: AbortSignal.timeout(5000) });
+            const resp = await fetch(url, { cache: 'reload', signal: AbortSignal.timeout(5000) });
             if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
             const data = await resp.json();
             // Cache to localStorage for offline fallback


### PR DESCRIPTION
## Summary

- **#34** METAR flight category dot colors updated to spec: VFR=green, MVFR=blue, IFR=red, LIFR=purple. FIS-B primary, internet METAR fallback.
- **#35** Towered airports show solid ring; non-towered show dashed ring (ForeFlight convention).
- **#37** White track vector extends 3 minutes ahead of ownship at current GS. Hidden on ground.
- **#40** Nearest baro station field in instrument strip — shows altimeter setting with source ICAO label.
- **fix** `cockpit-config.json` fetched with `cache: reload` — APK updates no longer silently ignored by WebView cache.

## Test plan

- [ ] Install v5.14 APK — **Clear Data first** (cockpit-config.json changed)
- [ ] Confirm SIM MODE banner does NOT appear (simMode reverted to false)
- [ ] Map: airport icons show dashed ring for non-towered, solid for towered
- [ ] Map: airports with METAR show colored dot (green/blue/red/purple)
- [ ] Map: white track vector extends ahead of ownship when airborne (GS > 10 kts)
- [ ] Map: track vector hidden on ground / in sim with GS = 0
- [ ] Instrument strip: BARO field present, shows altimeter and station ICAO once METAR data loads
- [ ] Instrument strip: BARO label updates to nearest station (e.g. KLKR) when in range

🤖 Generated with [Claude Code](https://claude.com/claude-code)