### PR TITLE
fix: airport labels, chart tile rendering, storage permission (v5.16)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ node_modules/
 *.aab
 *.aar
 
+# Reference screenshots — not part of source
+screenshots/
+
 # Local development / Claude Code
 .claude/settings.local.json
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "app.flywhere.flytab"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 514
-        versionName "5.14"
+        versionCode 516
+        versionName "5.16"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/android/app/src/main/java/app/flywhere/flytab/MainActivity.java
+++ b/android/app/src/main/java/app/flywhere/flytab/MainActivity.java
@@ -2,8 +2,11 @@ package app.flywhere.flytab;
 
 import android.app.AlertDialog;
 import android.content.Intent;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Environment;
+import android.provider.Settings;
 import android.util.Log;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
@@ -23,6 +26,12 @@ public class MainActivity extends BridgeActivity {
         registerPlugin(ThermalMonitorPlugin.class);
         registerPlugin(EngineMLPlugin.class);
         super.onCreate(savedInstanceState);
+
+        // Request "All files access" (MANAGE_EXTERNAL_STORAGE) — required to read
+        // MBTiles databases from Documents/FlyTab/tiles/ via the NanoHTTPD tile server.
+        // Must be requested at runtime via Settings on Android 11+; declaring in the
+        // manifest alone is not sufficient and the grant is revoked on reinstall.
+        checkStoragePermission();
 
         // Start flight service (keeps CPU awake for Stratux WebSocket when screen is off)
         startFlightService();
@@ -62,6 +71,24 @@ public class MainActivity extends BridgeActivity {
             }
             return ViewCompat.onApplyWindowInsets(v, insets);
         });
+    }
+
+    private void checkStoragePermission() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            if (!Environment.isExternalStorageManager()) {
+                new AlertDialog.Builder(this)
+                    .setTitle("Storage Access Required")
+                    .setMessage("FlyTab needs access to all files to read chart tiles and approach plates stored in Documents/FlyTab.\n\nTap OK to open the permission screen, then enable \"Allow management of all files\".")
+                    .setPositiveButton("OK", (dialog, which) -> {
+                        Intent intent = new Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION,
+                            Uri.parse("package:" + getPackageName()));
+                        startActivity(intent);
+                    })
+                    .setNegativeButton("Not now", null)
+                    .setCancelable(false)
+                    .show();
+            }
+        }
     }
 
     private void startFlightService() {

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,7 @@
  * Android Capacitor cockpit app. All data local. Pi for live telemetry only.
  */
 
-const FLYTAB_VERSION = 'v5.14';
+const FLYTAB_VERSION = 'v5.16';
 
 // ========== Diagnostic Logger (ring buffer in localStorage) ==========
 const DiagLog = (() => {

--- a/web/cockpit/vector-map-layers.js
+++ b/web/cockpit/vector-map-layers.js
@@ -166,7 +166,7 @@ class VectorMapLayers {
      * Hide lake fills so raster tiles show their own correct water rendering.
      */
     disableDarkBackground() {
-        this._map.getContainer().style.background = '';
+        this._map.getContainer().style.background = '#ffffff';
         if (this._map.hasLayer(this._lakesLayer)) this._map.removeLayer(this._lakesLayer);
     }
 
@@ -359,6 +359,13 @@ class VectorMapLayers {
         });
         dot.addTo(this._wxDotsLayer);
         this._wxDotMarkers.set(icao, dot);
+    }
+
+    /** CSS class for airport label size based on longest runway. */
+    _aptLabelClass(rwyFt) {
+        if (rwyFt >= 5000) return 'apt-label apt-label-lg';
+        if (rwyFt >= 3000) return 'apt-label apt-label-md';
+        return 'apt-label apt-label-sm';
     }
 
     /** Map flight category to hex color. */
@@ -988,13 +995,12 @@ class VectorMapLayers {
                     const m = this._airportMarkers.get(apt.icao);
                     const tip = m.getTooltip();
                     if (tip && tip.options.permanent !== labelVisible) {
-                        const towered2 = m._aptData?.tower;
                         m.unbindTooltip();
                         m.bindTooltip(apt.icao, {
                             permanent: labelVisible,
                             direction: 'right',
                             offset: [8, 0],
-                            className: towered2 ? 'apt-label apt-label-towered' : 'apt-label apt-label-nontowered',
+                            className: this._aptLabelClass(m._aptData?.longest_rwy_ft || 0),
                         });
                     }
                     continue;
@@ -1021,7 +1027,7 @@ class VectorMapLayers {
                     permanent: labelVisible,
                     direction: 'right',
                     offset: [8, 0],
-                    className: towered ? 'apt-label apt-label-towered' : 'apt-label apt-label-nontowered',
+                    className: this._aptLabelClass(apt.longest_rwy_ft || 0),
                 });
 
                 marker.on('click', () => {

--- a/web/style.css
+++ b/web/style.css
@@ -203,6 +203,7 @@
 .leaflet-container img.leaflet-tile {
     margin: 0;
     padding: 0;
+    mix-blend-mode: normal;
 }
 
 html {
@@ -4074,21 +4075,30 @@ body {
 /* ========== Airspace / Vector Map Labels ========== */
 
 .apt-label {
-    font: 700 14px var(--font-instrument);
-    padding: 1px 3px;
-    border: none;
-    box-shadow: none;
+    background: transparent !important;
+    border: none !important;
+    box-shadow: none !important;
+    padding: 0 !important;
+    font-family: var(--font-instrument);
+    font-weight: 700;
+    color: #111111;
+    text-shadow:
+        -1px -1px 0 #fff,
+         1px -1px 0 #fff,
+        -1px  1px 0 #fff,
+         1px  1px 0 #fff,
+         0    -1px 0 #fff,
+         0     1px 0 #fff,
+        -1px   0   0 #fff,
+         1px   0   0 #fff;
+    letter-spacing: 0.03em;
+    white-space: nowrap;
 }
+.apt-label::before { display: none !important; }
 
-.apt-label-towered {
-    color: #0055aa;
-    background: rgba(255,255,255,0.75);
-}
-
-.apt-label-nontowered {
-    color: #cc2299;
-    background: rgba(255,255,255,0.75);
-}
+.apt-label-lg { font-size: 13px; }
+.apt-label-md { font-size: 11px; }
+.apt-label-sm { font-size: 9px; }
 
 .airspace-label {
     font: 700 14px var(--font-instrument);


### PR DESCRIPTION
## Summary

- **ForeFlight-style airport labels**: Black text with white outline halo, font size based on longest runway length (lg ≥5000ft, md ≥3000ft, sm <3000ft). Replaces colored box-background labels. Adds `_aptLabelClass()` helper; removes unused `apt-label-towered`/`apt-label-nontowered` classes.
- **Chart tile rendering fix**: Overrides Leaflet's `mix-blend-mode: plus-lighter` with `normal` on tile images. The blend mode was making dark chart features (text, shorelines) invisible against the cockpit background after the opaque label backgrounds were removed. `disableDarkBackground()` now sets an explicit white background instead of transparent.
- **Storage permission on reinstall**: `MANAGE_EXTERNAL_STORAGE` was silently revoked on every APK reinstall (Android 11+ behavior), causing `TileServer: canRead=false` on all MBTiles files and breaking SEC/IFR/TAC charts. `MainActivity` now checks `Environment.isExternalStorageManager()` at startup and prompts the user to grant All Files Access if missing.

## Test plan

- [ ] Install fresh APK — permission dialog appears on first launch
- [ ] Grant All Files Access — SEC, IFR, TAC charts load correctly
- [ ] Airport labels show black text with white halo; large airports larger than small ones
- [ ] Reinstall APK — no permission prompt if already granted; charts still work

🤖 Generated with [Claude Code](https://claude.ai/claude-code)