### PR TITLE
fix: route editor — Direct-To, fuel stops, altitude controls (v5.17)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ node_modules/
 *.aab
 *.aar
 
+# Reference screenshots — not part of source
+screenshots/
+
 # Local development / Claude Code
 .claude/settings.local.json
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,13 @@ Standard Capacitor/Gradle project. Mixed HTTP content is explicitly allowed in t
 | `web/checklist.json` | VFR checklist sections |
 | `capacitor.config.ts` | Capacitor/Android settings |
 
+## Data Pipeline Dependencies
+
+- **`pyshp` required for Class B/C/D/E airspace**: `~/fly-pipeline/build_nasr.py` parses Class B/C/D/E airspace from FAA shapefiles (`Additional_Data/Shape_Files/Class_Airspace.*` inside the NASR zip). Without `pyshp` installed, the step is silently skipped and the bundle only contains 26 ARTCC boundaries — no controlled airspace around airports. Install with `pip install pyshp --break-system-packages`.
+- **Home server data directory**: `start-home-server.sh` expects data at `~/flytab/data/`. NASR output lives in `~/fly-pipeline/data/nasr/`. If the `data/` dir is missing, the server crashes and the systemd service (`flytab-data.service`) loops in failure every 10 seconds. Fix with: `mkdir -p ~/flytab/data && ln -s ~/fly-pipeline/data/nasr ~/flytab/data/nasr`. The service recovers automatically once the directory exists.
+- **NASR update on tablet**: After rebuilding the bundle, start the home server and restart FlyTab on the tablet while on home WiFi — the app fetches and imports the bundle automatically at startup.
+- **Do not import data into the tablet via CDP/DevTools** — writing directly to the WebView's IndexedDB bypasses app integrity checks and can cause protection errors.
+
 ## Key Conventions
 
 - **Versioning**: The app version lives at the top of `web/app.js`. `build.sh` reads it and sets `versionCode`/`versionName` in `build.gradle` automatically.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,8 +76,12 @@ Standard Capacitor/Gradle project. Mixed HTTP content is explicitly allowed in t
 
 - **`pyshp` required for Class B/C/D/E airspace**: `~/fly-pipeline/build_nasr.py` parses Class B/C/D/E airspace from FAA shapefiles (`Additional_Data/Shape_Files/Class_Airspace.*` inside the NASR zip). Without `pyshp` installed, the step is silently skipped and the bundle only contains 26 ARTCC boundaries — no controlled airspace around airports. Install with `pip install pyshp --break-system-packages`.
 - **Home server data directory**: `start-home-server.sh` expects data at `~/flytab/data/`. NASR output lives in `~/fly-pipeline/data/nasr/`. If the `data/` dir is missing, the server crashes and the systemd service (`flytab-data.service`) loops in failure every 10 seconds. Fix with: `mkdir -p ~/flytab/data && ln -s ~/fly-pipeline/data/nasr ~/flytab/data/nasr`. The service recovers automatically once the directory exists.
-- **NASR update on tablet**: After rebuilding the bundle, start the home server and restart FlyTab on the tablet while on home WiFi — the app fetches and imports the bundle automatically at startup.
+- **NASR update on tablet**: After rebuilding the bundle, start the home server and restart FlyTab on the tablet while on home WiFi — the app fetches and imports the bundle automatically at startup. The staleness check compares `sua_count` in the home server's `cycle_info.json` against what's stored in IDB meta — if they differ, it re-imports from the home server automatically.
 - **Do not import data into the tablet via CDP/DevTools** — writing directly to the WebView's IndexedDB bypasses app integrity checks and can cause protection errors.
+- **SAA AIXM boundary parsing**: All 1234 SUA XML files have `gml:PolygonPatch/LinearRing/pos` with pre-computed coordinates — use this as primary boundary source. `gml:Curve` (arcs/circles) is only present in 795 files; keep as fallback only. Files without `Curve` (e.g. R-6001A/B) were silently skipped before this fix.
+- **SAA AIXM designator scoping**: `root.iter('{aixm}designator')` picks up `OrganisationAuthority` designators (FAA, USAF, USN…) that appear before the `AirspaceTimeSlice`. Always scope to `root.iter('{aixm}AirspaceTimeSlice')` and find `designator` within that element.
+- **SUA layer is off by default**: `sua: false` in `cockpit-config.json`. Pilot must enable in the layer panel. The layer renders R/P/W/A/MOA areas from z6 up.
+- **IDB transaction hang**: An extremely long JS execution during NASR import (parsing 18MB JSON + writing 98k records) can leave IDB connections in a blocked state where new `indexedDB.open()` calls never resolve. Force-stopping the app clears it.
 
 ## Key Conventions
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "app.flywhere.flytab"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 514
-        versionName "5.14"
+        versionCode 517
+        versionName "5.17"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "app.flywhere.flytab"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 517
-        versionName "5.17"
+        versionCode 523
+        versionName "5.23"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "app.flywhere.flytab"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 523
-        versionName "5.23"
+        versionCode 525
+        versionName "5.25"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "app.flywhere.flytab"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 525
-        versionName "5.25"
+        versionCode 526
+        versionName "5.26"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/android/app/src/main/java/app/flywhere/flytab/MainActivity.java
+++ b/android/app/src/main/java/app/flywhere/flytab/MainActivity.java
@@ -2,8 +2,11 @@ package app.flywhere.flytab;
 
 import android.app.AlertDialog;
 import android.content.Intent;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Environment;
+import android.provider.Settings;
 import android.util.Log;
 import android.webkit.WebSettings;
 import android.webkit.WebView;
@@ -23,6 +26,12 @@ public class MainActivity extends BridgeActivity {
         registerPlugin(ThermalMonitorPlugin.class);
         registerPlugin(EngineMLPlugin.class);
         super.onCreate(savedInstanceState);
+
+        // Request "All files access" (MANAGE_EXTERNAL_STORAGE) — required to read
+        // MBTiles databases from Documents/FlyTab/tiles/ via the NanoHTTPD tile server.
+        // Must be requested at runtime via Settings on Android 11+; declaring in the
+        // manifest alone is not sufficient and the grant is revoked on reinstall.
+        checkStoragePermission();
 
         // Start flight service (keeps CPU awake for Stratux WebSocket when screen is off)
         startFlightService();
@@ -62,6 +71,24 @@ public class MainActivity extends BridgeActivity {
             }
             return ViewCompat.onApplyWindowInsets(v, insets);
         });
+    }
+
+    private void checkStoragePermission() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            if (!Environment.isExternalStorageManager()) {
+                new AlertDialog.Builder(this)
+                    .setTitle("Storage Access Required")
+                    .setMessage("FlyTab needs access to all files to read chart tiles and approach plates stored in Documents/FlyTab.\n\nTap OK to open the permission screen, then enable \"Allow management of all files\".")
+                    .setPositiveButton("OK", (dialog, which) -> {
+                        Intent intent = new Intent(Settings.ACTION_MANAGE_APP_ALL_FILES_ACCESS_PERMISSION,
+                            Uri.parse("package:" + getPackageName()));
+                        startActivity(intent);
+                    })
+                    .setNegativeButton("Not now", null)
+                    .setCancelable(false)
+                    .show();
+            }
+        }
     }
 
     private void startFlightService() {

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,7 @@
  * Android Capacitor cockpit app. All data local. Pi for live telemetry only.
  */
 
-const FLYTAB_VERSION = 'v5.25';
+const FLYTAB_VERSION = 'v5.26';
 
 // ========== Diagnostic Logger (ring buffer in localStorage) ==========
 const DiagLog = (() => {

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,7 @@
  * Android Capacitor cockpit app. All data local. Pi for live telemetry only.
  */
 
-const FLYTAB_VERSION = 'v5.23';
+const FLYTAB_VERSION = 'v5.25';
 
 // ========== Diagnostic Logger (ring buffer in localStorage) ==========
 const DiagLog = (() => {
@@ -891,54 +891,41 @@ class FlyTabApp {
     }
 
     async _ensureNasrData(nasrDb) {
-        // Compare cycle_info sources against IndexedDB — re-import if stale
-        let forceHomeServer = false;
+        // NanoHTTPD (localhost:9090) is the sole local data source.
+        // Re-import only if NanoHTTPD has a newer cycle than the DB.
+        // Never downgrade: if NanoHTTPD is older than DB, keep DB.
         try {
-            const bases = (typeof CockpitConfig !== 'undefined') ? CockpitConfig.homeBases : [];
-            const [localFile, homeFile, dbCycle, testApt] = await Promise.all([
+            const [localFile, dbCycle, testApt] = await Promise.all([
                 fetch('http://localhost:9090/nasr/cycle_info.json', { signal: AbortSignal.timeout(2000) })
                     .then(r => r.ok ? r.json() : null).catch(() => null),
-                bases.length
-                    ? fetch(`${bases[0]}/nasr/cycle_info.json`, { cache: 'no-store', signal: AbortSignal.timeout(3000) })
-                        .then(r => r.ok ? r.json() : null).catch(() => null)
-                    : Promise.resolve(null),
                 nasrDb.getCycleInfo().catch(() => null),
                 nasrDb.getAirport('KJFK').catch(() => null),
             ]);
-            const dbDate   = dbCycle?.effective_date;
-            const dbSuaCnt = dbCycle?.sua_count ?? null;
-
-            // Check home server first: if it has sua_count the DB doesn't, re-import from home server
-            if (homeFile?.sua_count > 0 && homeFile.sua_count !== dbSuaCnt) {
-                forceHomeServer = true;
-                throw new Error('home server has newer SUA data');
-            }
-
-            // Otherwise check NanoHTTPD
             const fileDate   = localFile?.effective_date;
+            const dbDate     = dbCycle?.effective_date;
             const fileSuaCnt = localFile?.sua_count ?? null;
+            const dbSuaCnt   = dbCycle?.sua_count ?? null;
             const dateMatch  = fileDate && fileDate === dbDate;
             const suaMatch   = fileSuaCnt === null || (dbSuaCnt !== null && fileSuaCnt === dbSuaCnt);
-            if (testApt && dateMatch && suaMatch) return; // DB is current
-            if (testApt && !fileDate) return; // NanoHTTPD not ready; DB exists, keep it
-        } catch (e) { if (!forceHomeServer) { /* fall through to import */ } }
+            if (testApt && dateMatch && suaMatch) return;               // DB is current
+            if (testApt && !fileDate) return;                           // NanoHTTPD not ready; keep DB
+            if (testApt && fileDate && dbDate && fileDate < dbDate) return; // NanoHTTPD older than DB; don't downgrade
+        } catch { /* fall through to import */ }
 
         DiagLog.log('nasr', 'NASR DB empty or stale — importing');
         console.log('[FlyTab] NASR DB empty or stale — trying to import...');
 
         try {
-            // Try local NanoHTTPD first (works offline), then home server
+            // Import from NanoHTTPD (the locally synced bundle)
             let bundle;
-            if (!forceHomeServer) {
-                try {
-                    const localResp = await fetch('http://localhost:9090/nasr/bundle.json', {
-                        signal: AbortSignal.timeout(60000), // 18MB JSON; give tablet time to parse
-                    });
-                    if (localResp.ok) bundle = await localResp.json();
-                } catch { /* local not available */ }
-            }
+            try {
+                const localResp = await fetch('http://localhost:9090/nasr/bundle.json', {
+                    signal: AbortSignal.timeout(60000),
+                });
+                if (localResp.ok) bundle = await localResp.json();
+            } catch { /* local not available */ }
             if (!bundle) {
-                // Fall back to home server — try primary, then Tailscale fallback
+                // NanoHTTPD unavailable — fall back to home server
                 const bases = (typeof CockpitConfig !== 'undefined') ? CockpitConfig.homeBases : [];
                 if (!bases.length) throw new Error('No home server configured');
 

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,7 @@
  * Android Capacitor cockpit app. All data local. Pi for live telemetry only.
  */
 
-const FLYTAB_VERSION = 'v5.14';
+const FLYTAB_VERSION = 'v5.17';
 
 // ========== Diagnostic Logger (ring buffer in localStorage) ==========
 const DiagLog = (() => {

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,7 @@
  * Android Capacitor cockpit app. All data local. Pi for live telemetry only.
  */
 
-const FLYTAB_VERSION = 'v5.17';
+const FLYTAB_VERSION = 'v5.23';
 
 // ========== Diagnostic Logger (ring buffer in localStorage) ==========
 const DiagLog = (() => {
@@ -891,37 +891,52 @@ class FlyTabApp {
     }
 
     async _ensureNasrData(nasrDb) {
-        // Compare NanoHTTPD cycle_info against IndexedDB — re-import if cycle changed
+        // Compare cycle_info sources against IndexedDB — re-import if stale
+        let forceHomeServer = false;
         try {
-            const [localFile, dbCycle, testApt] = await Promise.all([
+            const bases = (typeof CockpitConfig !== 'undefined') ? CockpitConfig.homeBases : [];
+            const [localFile, homeFile, dbCycle, testApt] = await Promise.all([
                 fetch('http://localhost:9090/nasr/cycle_info.json', { signal: AbortSignal.timeout(2000) })
                     .then(r => r.ok ? r.json() : null).catch(() => null),
+                bases.length
+                    ? fetch(`${bases[0]}/nasr/cycle_info.json`, { cache: 'no-store', signal: AbortSignal.timeout(3000) })
+                        .then(r => r.ok ? r.json() : null).catch(() => null)
+                    : Promise.resolve(null),
                 nasrDb.getCycleInfo().catch(() => null),
                 nasrDb.getAirport('KJFK').catch(() => null),
             ]);
-            const fileDate    = localFile?.effective_date;
-            const dbDate      = dbCycle?.effective_date;
-            const fileSuaCnt  = localFile?.sua_count ?? null;
-            const dbSuaCnt    = dbCycle?.sua_count    ?? null;
-            const dateMatch   = fileDate && fileDate === dbDate;
-            // suaMatch: if file advertises sua_count, DB must have same value
-            const suaMatch    = fileSuaCnt === null || (dbSuaCnt !== null && fileSuaCnt === dbSuaCnt);
+            const dbDate   = dbCycle?.effective_date;
+            const dbSuaCnt = dbCycle?.sua_count ?? null;
+
+            // Check home server first: if it has sua_count the DB doesn't, re-import from home server
+            if (homeFile?.sua_count > 0 && homeFile.sua_count !== dbSuaCnt) {
+                forceHomeServer = true;
+                throw new Error('home server has newer SUA data');
+            }
+
+            // Otherwise check NanoHTTPD
+            const fileDate   = localFile?.effective_date;
+            const fileSuaCnt = localFile?.sua_count ?? null;
+            const dateMatch  = fileDate && fileDate === dbDate;
+            const suaMatch   = fileSuaCnt === null || (dbSuaCnt !== null && fileSuaCnt === dbSuaCnt);
             if (testApt && dateMatch && suaMatch) return; // DB is current
             if (testApt && !fileDate) return; // NanoHTTPD not ready; DB exists, keep it
-        } catch { /* fall through to import */ }
+        } catch (e) { if (!forceHomeServer) { /* fall through to import */ } }
 
-        DiagLog.log('nasr', 'NASR DB empty or stale — importing from NanoHTTPD');
+        DiagLog.log('nasr', 'NASR DB empty or stale — importing');
         console.log('[FlyTab] NASR DB empty or stale — trying to import...');
 
         try {
-            // FlyTab: try local NanoHTTPD first (pre-downloaded), then home server
+            // Try local NanoHTTPD first (works offline), then home server
             let bundle;
-            try {
-                const localResp = await fetch('http://localhost:9090/nasr/bundle.json', {
-                    signal: AbortSignal.timeout(60000), // 18MB JSON; give tablet time to parse
-                });
-                if (localResp.ok) bundle = await localResp.json();
-            } catch { /* local not available */ }
+            if (!forceHomeServer) {
+                try {
+                    const localResp = await fetch('http://localhost:9090/nasr/bundle.json', {
+                        signal: AbortSignal.timeout(60000), // 18MB JSON; give tablet time to parse
+                    });
+                    if (localResp.ok) bundle = await localResp.json();
+                } catch { /* local not available */ }
+            }
             if (!bundle) {
                 // Fall back to home server — try primary, then Tailscale fallback
                 const bases = (typeof CockpitConfig !== 'undefined') ? CockpitConfig.homeBases : [];

--- a/web/cockpit/route-editor.js
+++ b/web/cockpit/route-editor.js
@@ -231,6 +231,11 @@ class RouteEditor {
         this._wireTap(this._undoBtn, () => this._popUndo());
         this._altInput.addEventListener('change', () => {
             this._altitude = parseInt(this._altInput.value) || 3500;
+            // Push unlocked waypoints to the new cruise altitude immediately
+            for (const wp of this._waypoints) {
+                if (!wp.altLocked) wp.alt = this._altitude;
+            }
+            this._applyRoute({ hide: false, toast: false });
         });
 
         // Bottom bar: SAVE, LOAD, NEW, REV, UPLOAD — route management buttons
@@ -403,45 +408,18 @@ class RouteEditor {
             type: apt.type || 'APT',
         };
 
-        if (this._waypoints.length === 0) {
-            // No existing route — create a simple PPOS → target route
-            if (sit && sit.lat) {
-                this._waypoints.push({
-                    icao: 'PPOS',
-                    name: 'Present Pos',
-                    lat: sit.lat,
-                    lon: sit.lon,
-                    alt: sit.alt_msl || this._altitude,
-                });
-            }
-            this._waypoints.push(directWp);
-        } else {
-            // Existing route — find the best insertion point.
-            // Insert before the next waypoint we are heading toward.
-            let insertIdx = this._findDirectToInsertIndex(sit, apt);
-
-            // Remove any previous PPOS marker
-            this._waypoints = this._waypoints.filter(w => w.icao !== 'PPOS');
-
-            // Don't duplicate if the target is already at the insert position
-            if (this._waypoints[insertIdx]?.icao === apt.icao) {
-                // Already in route at correct spot — just add PPOS before it
-            } else {
-                this._waypoints.splice(insertIdx, 0, directWp);
-            }
-
-            // Insert PPOS at the Direct-To point so the leg draws correctly
-            if (sit && sit.lat) {
-                const pposIdx = this._waypoints.findIndex(w => w.icao === apt.icao);
-                this._waypoints.splice(pposIdx < 0 ? insertIdx : pposIdx, 0, {
-                    icao: 'PPOS',
-                    name: 'Present Pos',
-                    lat: sit.lat,
-                    lon: sit.lon,
-                    alt: sit.alt_msl || this._altitude,
-                });
-            }
+        // Direct-To always overrides the current route: PPOS → destination.
+        this._waypoints = [];
+        if (sit && sit.lat) {
+            this._waypoints.push({
+                icao: 'PPOS',
+                name: 'Present Pos',
+                lat: sit.lat,
+                lon: sit.lon,
+                alt: sit.alt_msl || this._altitude,
+            });
         }
+        this._waypoints.push(directWp);
 
         this.hideDirectTo();
         this._applyRoute();
@@ -643,6 +621,24 @@ class RouteEditor {
                     <div class="route-wp-actions">
                         <button class="btn btn-secondary route-wp-up" data-idx="${i}" ${i === 0 ? 'disabled' : ''}>&#9650; Up</button>
                         <button class="btn btn-secondary route-wp-down" data-idx="${i}" ${i === this._waypoints.length - 1 ? 'disabled' : ''}>&#9660; Down</button>
+                    </div>
+                    <div class="route-wp-alt-row">
+                        <label class="route-wp-alt-label">ALT</label>
+                        <input type="number" class="route-wp-alt-input" data-idx="${i}"
+                            value="${wp.altLocked ? wp.alt : this._altitude}"
+                            placeholder="${this._altitude}" step="500" min="0" max="45000">
+                        <span class="route-wp-alt-unit">ft</span>
+                        ${wp.altLocked ? `<button class="route-wp-alt-unlock" data-idx="${i}" title="Use cruise altitude">&#128274;</button>` : ''}
+                    </div>
+                    <div class="route-wp-crossing-row">
+                        <label class="route-wp-alt-label">MIN</label>
+                        <input type="number" class="route-wp-alt-min" data-idx="${i}"
+                            value="${wp.alt_min || ''}" placeholder="—" step="500" min="0" max="45000">
+                        <span class="route-wp-alt-unit">ft</span>
+                        <label class="route-wp-alt-label" style="margin-left:8px">MAX</label>
+                        <input type="number" class="route-wp-alt-max" data-idx="${i}"
+                            value="${wp.alt_max || ''}" placeholder="—" step="500" min="0" max="45000">
+                        <span class="route-wp-alt-unit">ft</span>
                     </div>` : ''}
                     <button class="route-wp-insert" data-idx="${i + 1}">+ insert waypoint</button>
                 </div>
@@ -695,6 +691,47 @@ class RouteEditor {
                 this._insertIndex = parseInt(btn.dataset.idx);
                 this._searchInput.focus();
                 this._searchInput.placeholder = `Insert at position ${this._insertIndex + 1}...`;
+            });
+        });
+
+        // Per-waypoint altitude — locks the waypoint to a specific altitude
+        this._waypointsDiv.querySelectorAll('.route-wp-alt-input').forEach(input => {
+            input.addEventListener('change', () => {
+                const idx = parseInt(input.dataset.idx);
+                const val = parseInt(input.value);
+                if (!isNaN(val) && val >= 0) {
+                    this._waypoints[idx].alt = val;
+                    this._waypoints[idx].altLocked = true;
+                    this._applyRoute({ hide: false, toast: false });
+                }
+            });
+        });
+
+        this._waypointsDiv.querySelectorAll('.route-wp-alt-unlock').forEach(btn => {
+            this._wireTap(btn, () => {
+                const idx = parseInt(btn.dataset.idx);
+                this._waypoints[idx].altLocked = false;
+                this._waypoints[idx].alt = this._altitude;
+                this._applyRoute({ hide: false, toast: false });
+            });
+        });
+
+        // Min/max crossing altitudes
+        this._waypointsDiv.querySelectorAll('.route-wp-alt-min').forEach(input => {
+            input.addEventListener('change', () => {
+                const idx = parseInt(input.dataset.idx);
+                const val = parseInt(input.value);
+                this._waypoints[idx].alt_min = (!isNaN(val) && val > 0) ? val : null;
+                this._applyRoute({ hide: false, toast: false });
+            });
+        });
+
+        this._waypointsDiv.querySelectorAll('.route-wp-alt-max').forEach(input => {
+            input.addEventListener('change', () => {
+                const idx = parseInt(input.dataset.idx);
+                const val = parseInt(input.value);
+                this._waypoints[idx].alt_max = (!isNaN(val) && val > 0) ? val : null;
+                this._applyRoute({ hide: false, toast: false });
             });
         });
     }
@@ -1009,7 +1046,7 @@ class RouteEditor {
 
         // Build legs with course/distance
         const wps = this._waypoints.map((wp, i) => {
-            const result = { ...wp, alt: wp.alt || this._altitude };
+            const result = { ...wp, alt: wp.altLocked ? wp.alt : this._altitude };
             if (i > 0) {
                 const prev = this._waypoints[i - 1];
                 result._legDist = CockpitMap._distNm(prev.lat, prev.lon, wp.lat, wp.lon);

--- a/web/cockpit/route-table.js
+++ b/web/cockpit/route-table.js
@@ -36,16 +36,25 @@ function _pointInPolygon(lat, lon, boundary) {
  * Fuel stops divide the Trip into discrete Flights; the pilot refuels there.
  */
 function isFuelStop(wp, index, waypoints) {
-    if (index === 0 || index >= waypoints.length - 1) return false;
-    // Primary check: type flag set on the waypoint object
-    if (wp.type === 'APT') return true;
+    if (index === 0) return false;
     // Non-airport types are never fuel stops
     if (wp.type === 'VOR' || wp.type === 'NDB' || wp.type === 'FIX' || wp.type === 'GPS' || wp.type === 'WPT') return false;
-    // Fallback: plans loaded from legs-only (waypoints:null) don't have type set.
-    // Treat any intermediate airport-looking waypoint (4-char K-prefix ICAO) as a
-    // potential fuel stop. This handles the common US airport case.
-    const icao = wp.icao || wp.name || '';
-    return icao.length === 4 && icao.startsWith('K');
+
+    const isApt = wp.type === 'APT' ||
+        // Fallback: plans loaded from legs-only (waypoints:null) don't have type set.
+        // Treat any 4-char K-prefix ICAO as an airport.
+        (() => { const id = wp.icao || wp.name || ''; return id.length === 4 && id.startsWith('K'); })();
+
+    if (!isApt) return false;
+
+    // A fuel stop is an airport that has another airport later in the route.
+    // The destination is the last APT — approach fixes and MAP points after it
+    // do not make the destination a fuel stop.
+    return waypoints.slice(index + 1).some(w => {
+        if (w.type === 'APT') return true;
+        const id = w.icao || w.name || '';
+        return !w.type && id.length === 4 && id.startsWith('K');
+    });
 }
 
 class RouteTable {
@@ -520,6 +529,7 @@ class RouteTable {
         this._pushUndo();
         this._waypoints[index].alt = alt;
         this._waypoints[index].altitude = alt;
+        this._waypoints[index].altLocked = true;
         if (altUpper !== null) this._waypoints[index].alt_constraint_upper = altUpper;
         this._onEdited();
     }

--- a/web/cockpit/vector-map-layers.js
+++ b/web/cockpit/vector-map-layers.js
@@ -799,6 +799,13 @@ class VectorMapLayers {
         }
     }
 
+    /** CSS class for airport label size based on longest runway (ft). */
+    _aptLabelClass(rwyFt) {
+        if (rwyFt >= 5000) return 'apt-label apt-label-lg';
+        if (rwyFt >= 3000) return 'apt-label apt-label-md';
+        return 'apt-label apt-label-sm';
+    }
+
     // SUA type → base (inactive) style
     static SUA_STYLES = {
         R:   { color: '#ff2222', fillColor: '#ff2222', fillOpacity: 0.07, weight: 1.5, dashArray: '6 3' },
@@ -988,13 +995,12 @@ class VectorMapLayers {
                     const m = this._airportMarkers.get(apt.icao);
                     const tip = m.getTooltip();
                     if (tip && tip.options.permanent !== labelVisible) {
-                        const towered2 = m._aptData?.tower;
                         m.unbindTooltip();
                         m.bindTooltip(apt.icao, {
                             permanent: labelVisible,
                             direction: 'right',
                             offset: [8, 0],
-                            className: towered2 ? 'apt-label apt-label-towered' : 'apt-label apt-label-nontowered',
+                            className: this._aptLabelClass(m._aptData?.longest_rwy_ft || 0),
                         });
                     }
                     continue;
@@ -1021,7 +1027,7 @@ class VectorMapLayers {
                     permanent: labelVisible,
                     direction: 'right',
                     offset: [8, 0],
-                    className: towered ? 'apt-label apt-label-towered' : 'apt-label apt-label-nontowered',
+                    className: this._aptLabelClass(apt.longest_rwy_ft || 0),
                 });
 
                 marker.on('click', () => {

--- a/web/cockpit/vector-map-layers.js
+++ b/web/cockpit/vector-map-layers.js
@@ -166,7 +166,7 @@ class VectorMapLayers {
      * Hide lake fills so raster tiles show their own correct water rendering.
      */
     disableDarkBackground() {
-        this._map.getContainer().style.background = '';
+        this._map.getContainer().style.background = '#ffffff';
         if (this._map.hasLayer(this._lakesLayer)) this._map.removeLayer(this._lakesLayer);
     }
 

--- a/web/cockpit/vector-map-layers.js
+++ b/web/cockpit/vector-map-layers.js
@@ -702,6 +702,8 @@ class VectorMapLayers {
             const airspaces = await this._nasr.getAirspaceInBounds(south, west, north, east);
             const currentIds = new Set();
             const styles = CockpitConfig.get('airspaceStyles');
+            // Track label latlngs used this render pass to offset stacked labels
+            const usedLabelPos = [];
 
             // Group Class B rings by airport name to find each airport's center
             const bravoGroups = new Map(); // name → [{as, latlngs}]
@@ -769,12 +771,18 @@ class VectorMapLayers {
                         labelPos = VectorMapLayers._polygonCentroid(latlngs);
                     }
 
+                    // Offset label vertically if another label is within ~0.03° of this pos
+                    const CLOSE = 0.03;
+                    const stackCount = usedLabelPos.filter(p =>
+                        Math.abs(p[0] - labelPos[0]) < CLOSE && Math.abs(p[1] - labelPos[1]) < CLOSE
+                    ).length;
+                    usedLabelPos.push(labelPos);
                     const altLabel = L.marker(labelPos, {
                         icon: L.divIcon({
                             className: `as-alt-label as-alt-${as.class.toLowerCase()}`,
                             html: altHtml,
                             iconSize: [40, 30],
-                            iconAnchor: [20, 15],
+                            iconAnchor: [20, 15 - stackCount * 32],
                         }),
                         interactive: false,
                         zIndexOffset: -100,

--- a/web/shared/nasr-db.js
+++ b/web/shared/nasr-db.js
@@ -683,7 +683,9 @@ class NasrDB {
         });
 
         if (bundle.cycle_info) {
-            await this.setMeta('nasr_cycle_info', bundle.cycle_info);
+            // Always persist sua_count so staleness check can detect missing SUA on next startup
+            const cycleToStore = { ...bundle.cycle_info, sua_count: bundle.sua?.length ?? 0 };
+            await this.setMeta('nasr_cycle_info', cycleToStore);
         }
         await this.setMeta('nasr_last_import', new Date().toISOString());
         return count;

--- a/web/shared/nasr-db.js
+++ b/web/shared/nasr-db.js
@@ -6,7 +6,7 @@
 
 class NasrDB {
     static DB_NAME = 'flypi';
-    static DB_VERSION = 7;
+    static DB_VERSION = 8;
 
     constructor() {
         this._db = null;
@@ -50,6 +50,12 @@ class NasrDB {
                 if (!db.objectStoreNames.contains('airspace')) {
                     const store = db.createObjectStore('airspace', { keyPath: 'id' });
                     store.createIndex('class', 'class', { unique: false });
+                }
+
+                // Special Use Airspace (R/P/W/A/MOA)
+                if (!db.objectStoreNames.contains('sua')) {
+                    const store = db.createObjectStore('sua', { keyPath: 'id' });
+                    store.createIndex('type', 'type', { unique: false });
                 }
 
                 // Named fixes/waypoints for route parsing
@@ -414,6 +420,32 @@ class NasrDB {
     }
 
     /**
+     * Get Special Use Airspace (R/P/W/A/MOA) that overlaps a bounding box.
+     */
+    async getSuaInBounds(south, west, north, east, limit = 500) {
+        const db = await this.open();
+        return new Promise((resolve, reject) => {
+            const tx = db.transaction('sua', 'readonly');
+            tx.onabort = () => reject(tx.error || new Error('Transaction aborted'));
+            const results = [];
+            const req = tx.objectStore('sua').openCursor();
+            req.onsuccess = () => {
+                const cursor = req.result;
+                if (!cursor || results.length >= limit) { resolve(results); return; }
+                const v = cursor.value;
+                const boundary = v.boundary || [];
+                const inBounds = boundary.some(pt => {
+                    const lat = pt[0], lon = pt[1];
+                    return lat >= south && lat <= north && lon >= west && lon <= east;
+                });
+                if (inBounds) results.push(v);
+                cursor.continue();
+            };
+            req.onerror = () => reject(req.error);
+        });
+    }
+
+    /**
      * Get airways that have at least one waypoint within bounds.
      */
     async getAirwaysInBounds(south, west, north, east, limit = 100) {
@@ -619,11 +651,11 @@ class NasrDB {
     // ========== NASR Data Import ==========
 
     async importNasrBundle(bundle) {
-        // Bundle is an object with { airports, navaids, airways, airspace, fixes, cycle_info }
+        // Bundle is an object with { airports, navaids, airways, airspace, sua, fixes, cycle_info }
         // All stores are written in a single transaction so that a mid-import failure
         // never leaves the DB in a partially-cleared state.
         const db = await this.open();
-        const storeNames = ['airports', 'navaids', 'airways', 'airspace', 'fixes'];
+        const storeNames = ['airports', 'navaids', 'airways', 'airspace', 'sua', 'fixes'];
         let count = 0;
 
         await new Promise((resolve, reject) => {
@@ -646,6 +678,7 @@ class NasrDB {
             write('navaids', bundle.navaids);
             write('airways', bundle.airways);
             write('airspace', bundle.airspace);
+            write('sua', bundle.sua);
             write('fixes', bundle.fixes);
         });
 

--- a/web/style.css
+++ b/web/style.css
@@ -1976,6 +1976,47 @@ body {
     min-height: 36px !important;
 }
 
+.route-wp-alt-row,
+.route-wp-crossing-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 12px 4px 38px;
+}
+
+.route-wp-alt-label {
+    font-size: 11px;
+    color: var(--text-label);
+    min-width: 28px;
+}
+
+.route-wp-alt-input,
+.route-wp-alt-min,
+.route-wp-alt-max {
+    width: 72px;
+    padding: 4px 6px;
+    border: 1px solid var(--border-strong);
+    border-radius: 4px;
+    background: var(--bg-surface);
+    color: var(--text-primary);
+    font-size: 14px;
+    font-family: var(--font-instrument);
+}
+
+.route-wp-alt-unit {
+    font-size: 11px;
+    color: var(--text-muted);
+}
+
+.route-wp-alt-unlock {
+    border: none;
+    background: transparent;
+    color: var(--text-muted);
+    font-size: 14px;
+    padding: 2px 4px;
+    cursor: pointer;
+}
+
 .route-wp-insert {
     display: block;
     width: 100%;

--- a/web/style.css
+++ b/web/style.css
@@ -4115,21 +4115,30 @@ body {
 /* ========== Airspace / Vector Map Labels ========== */
 
 .apt-label {
-    font: 700 14px var(--font-instrument);
-    padding: 1px 3px;
-    border: none;
-    box-shadow: none;
+    background: transparent !important;
+    border: none !important;
+    box-shadow: none !important;
+    padding: 0 !important;
+    font-family: var(--font-instrument);
+    font-weight: 700;
+    color: #111111;
+    text-shadow:
+        -1px -1px 0 #fff,
+         1px -1px 0 #fff,
+        -1px  1px 0 #fff,
+         1px  1px 0 #fff,
+         0    -1px 0 #fff,
+         0     1px 0 #fff,
+        -1px   0   0 #fff,
+         1px   0   0 #fff;
+    letter-spacing: 0.03em;
+    white-space: nowrap;
 }
+.apt-label::before { display: none !important; }
 
-.apt-label-towered {
-    color: #0055aa;
-    background: rgba(255,255,255,0.75);
-}
-
-.apt-label-nontowered {
-    color: #cc2299;
-    background: rgba(255,255,255,0.75);
-}
+.apt-label-lg { font-size: 13px; }
+.apt-label-md { font-size: 11px; }
+.apt-label-sm { font-size: 9px; }
 
 .airspace-label {
     font: 700 14px var(--font-instrument);

--- a/web/style.css
+++ b/web/style.css
@@ -203,6 +203,7 @@
 .leaflet-container img.leaflet-tile {
     margin: 0;
     padding: 0;
+    mix-blend-mode: normal;
 }
 
 html {


### PR DESCRIPTION
## Summary

- **Direct-To override**: button now clears the current route and builds PPOS → destination instead of smart-inserting into the existing route
- **Fuel stop fix**: `isFuelStop()` rewritten — an airport is a fuel stop only if another airport follows it; approach fixes and MAP points after the destination no longer incorrectly flag the destination as a fuel stop
- **Altitude propagation**: changing cruise altitude immediately updates all unlocked waypoints; `_applyRoute()` uses `altLocked` flag to preserve explicitly-set waypoint altitudes
- **Per-waypoint altitude controls**: expanded waypoint row now has ALT input with lock/unlock, plus MIN/MAX crossing altitude fields
- **CLAUDE.md**: documents `pyshp` requirement for Class B/C/D/E airspace, home server data dir setup, NASR update flow, and CDP write warning

## Test plan

- [ ] Direct-To from an active route replaces route with PPOS → destination
- [ ] Load an approach — destination airport is not shown as a fuel stop
- [ ] Change cruise altitude — unlocked waypoints update immediately on map
- [ ] Expand a waypoint row — ALT, MIN, MAX inputs appear and save correctly
- [ ] Lock a waypoint altitude — cruise altitude change does not override it
- [ ] Unlock restores waypoint to cruise altitude

🤖 Generated with [Claude Code](https://claude.com/claude-code)