### PR TITLE
fix: SUA altitude labels — collision dedup and text-shadow readability (v5.39)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "app.flywhere.flytab"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 536
-        versionName "5.36"
+        versionCode 537
+        versionName "5.37"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "app.flywhere.flytab"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 538
-        versionName "5.38"
+        versionCode 539
+        versionName "5.39"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "app.flywhere.flytab"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 537
-        versionName "5.37"
+        versionCode 538
+        versionName "5.38"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,7 @@
  * Android Capacitor cockpit app. All data local. Pi for live telemetry only.
  */
 
-const FLYTAB_VERSION = 'v5.36';
+const FLYTAB_VERSION = 'v5.37';
 
 // ========== Diagnostic Logger (ring buffer in localStorage) ==========
 const DiagLog = (() => {
@@ -116,6 +116,9 @@ class FlyTabApp {
     }
 
     async init() {
+        // Activate cockpit CSS token system — dark sunlight-readable theme
+        document.documentElement.dataset.mode = 'cockpit';
+
         // Load cockpit config
         if (typeof CockpitConfig !== 'undefined') {
             await CockpitConfig.load();

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,7 @@
  * Android Capacitor cockpit app. All data local. Pi for live telemetry only.
  */
 
-const FLYTAB_VERSION = 'v5.38';
+const FLYTAB_VERSION = 'v5.39';
 
 // ========== Diagnostic Logger (ring buffer in localStorage) ==========
 const DiagLog = (() => {

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,7 @@
  * Android Capacitor cockpit app. All data local. Pi for live telemetry only.
  */
 
-const FLYTAB_VERSION = 'v5.37';
+const FLYTAB_VERSION = 'v5.38';
 
 // ========== Diagnostic Logger (ring buffer in localStorage) ==========
 const DiagLog = (() => {
@@ -116,9 +116,6 @@ class FlyTabApp {
     }
 
     async init() {
-        // Activate cockpit CSS token system — dark sunlight-readable theme
-        document.documentElement.dataset.mode = 'cockpit';
-
         // Load cockpit config
         if (typeof CockpitConfig !== 'undefined') {
             await CockpitConfig.load();

--- a/web/cockpit/vector-map-layers.js
+++ b/web/cockpit/vector-map-layers.js
@@ -847,6 +847,7 @@ class VectorMapLayers {
         try {
             const areas = await this._nasr.getSuaInBounds(south, west, north, east);
             const currentIds = new Set();
+            const usedLabelPos = [];
 
             for (const sua of areas) {
                 currentIds.add(sua.id);
@@ -895,19 +896,27 @@ class VectorMapLayers {
                 polygon.addTo(this._suaLayer);
                 this._suaPolygons.set(sua.id, polygon);
 
-                // Altitude label at centroid
-                const center = VectorMapLayers._polygonCentroid(latlngs);
+                // Altitude label at centroid with collision offset
+                let labelPos = VectorMapLayers._polygonCentroid(latlngs);
                 const altLower = sua.lower_ft === 0 ? 'SFC' : (sua.lower_ft >= 1000 ? `${Math.round(sua.lower_ft / 100)}` : sua.lower_ft);
                 const altUpper = sua.upper_ft != null ? (sua.upper_ft >= 1000 ? `${Math.round(sua.upper_ft / 100)}` : sua.upper_ft) : '?';
                 const actBadge = isActive ? '<span class="sua-act-badge">ACT</span>' : '';
                 const altHtml  = `${altUpper}<br><span class="as-alt-floor">${altLower}</span>${actBadge}`;
                 const typeClass = `sua-lbl-${(sua.type || 'moa').toLowerCase()}`;
-                const label = L.marker(center, {
+
+                // Offset label vertically if another label is within ~0.05° of this pos
+                const SUA_CLOSE = 0.05;
+                const stackCount = usedLabelPos.filter(p =>
+                    Math.abs(p[0] - labelPos[0]) < SUA_CLOSE && Math.abs(p[1] - labelPos[1]) < SUA_CLOSE
+                ).length;
+                usedLabelPos.push(labelPos);
+
+                const label = L.marker(labelPos, {
                     icon: L.divIcon({
                         className: `as-alt-label ${typeClass}${isActive ? ' sua-lbl-active' : ''}`,
                         html: altHtml,
-                        iconSize: [44, 34],
-                        iconAnchor: [22, 17],
+                        iconSize: [48, 34],
+                        iconAnchor: [24, 17 - stackCount * 38],
                     }),
                     interactive: false,
                     zIndexOffset: -150,

--- a/web/style.css
+++ b/web/style.css
@@ -132,6 +132,7 @@
     --status-danger:     #ff3030;   /* danger / exceeding limits                 */
 
     /* Retained aliases for existing code */
+    --text-dim:          #888888;   /* dim hints, fallback for missing theme var  */
     --color-success:     #00e87a;
     --color-caution:     #ffc000;
     --color-danger:      #ff3030;
@@ -4155,9 +4156,12 @@ body {
     font: 700 14px var(--font-instrument);
     text-align: center;
     line-height: 1.1;
-    background: none;
+    background: rgba(0, 0, 0, 0.45);
     border: none;
+    border-radius: 2px;
+    padding: 1px 3px;
     pointer-events: none;
+    white-space: nowrap;
 }
 
 .as-alt-floor {
@@ -6453,7 +6457,7 @@ body {
 
 .apt-chip:active {
     background: var(--accent);
-    color: #000;
+    color: var(--text-on-accent);
 }
 
 .apt-tabs {

--- a/web/style.css
+++ b/web/style.css
@@ -4156,12 +4156,11 @@ body {
     font: 700 14px var(--font-instrument);
     text-align: center;
     line-height: 1.1;
-    background: rgba(0, 0, 0, 0.45);
+    background: none;
     border: none;
-    border-radius: 2px;
-    padding: 1px 3px;
     pointer-events: none;
     white-space: nowrap;
+    text-shadow: 0 0 3px #fff, 0 0 3px #fff, 0 0 3px #fff;
 }
 
 .as-alt-floor {


### PR DESCRIPTION
## Summary
- **#65** SUA altitude labels overlapping/unreadable — adds `usedLabelPos` deduplication matching the Class B/C pattern; labels within 0.05° are offset vertically to prevent stacking. Replaces grey background box with white text-shadow halo for contrast against any map tile.
- Defines missing `--text-dim` CSS variable (was falling through to inherited color in airport popup hint text)
- Fixes `.apt-chip:active` to use `var(--text-on-accent)` instead of hardcoded `#000`

## Test plan
- [ ] Enable SUA layer, zoom to area with adjacent R/MOA areas, confirm labels don't overlap
- [ ] Confirm altitude labels readable against terrain, sectional, and satellite tiles
- [ ] Confirm no grey background box on SUA labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)