### PR TITLE
Approach loading, CIFP download, startup data check (v5.57–v5.67)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "app.flywhere.flytab"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 562
-        versionName "5.62"
+        versionCode 567
+        versionName "5.67"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "app.flywhere.flytab"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 559
-        versionName "5.59"
+        versionCode 560
+        versionName "5.60"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "app.flywhere.flytab"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 560
-        versionName "5.60"
+        versionCode 561
+        versionName "5.61"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "app.flywhere.flytab"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 561
-        versionName "5.61"
+        versionCode 562
+        versionName "5.62"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/start-home-server.sh
+++ b/start-home-server.sh
@@ -132,6 +132,11 @@ class FlyTabHandler(http.server.SimpleHTTPRequestHandler):
             self._handle_terrain_grid_status()
             return
 
+        # /cifp/cifp.zip — on-the-fly zip of bundle + cycle_info for fetch-zip download
+        if path_only == '/cifp/cifp.zip':
+            self._handle_cifp_zip()
+            return
+
         # Everything else served from data/
         super().do_GET()
 
@@ -381,6 +386,26 @@ class FlyTabHandler(http.server.SimpleHTTPRequestHandler):
                 if not chunk:
                     break
                 self.wfile.write(chunk)
+
+    def _handle_cifp_zip(self):
+        import io, zipfile as zf
+        bundle_path = os.path.join(DATA_DIR, 'cifp', 'cifp_bundle.json')
+        cycle_path  = os.path.join(DATA_DIR, 'cifp', 'cifp_cycle_info.json')
+        if not os.path.isfile(bundle_path):
+            self.send_error(404, 'cifp_bundle.json not found')
+            return
+        buf = io.BytesIO()
+        with zf.ZipFile(buf, 'w', zf.ZIP_DEFLATED) as z:
+            z.write(bundle_path,  'cifp/cifp_bundle.json')
+            if os.path.isfile(cycle_path):
+                z.write(cycle_path, 'cifp/cifp_cycle_info.json')
+        data = buf.getvalue()
+        self.send_response(200)
+        self.send_header('Content-Type', 'application/zip')
+        self.send_header('Content-Length', str(len(data)))
+        self.send_header('Cache-Control', 'no-cache')
+        self.end_headers()
+        self.wfile.write(data)
 
     def do_PUT(self):
         # Allow writing specific config files back to data/

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,7 @@
  * Android Capacitor cockpit app. All data local. Pi for live telemetry only.
  */
 
-const FLYTAB_VERSION = 'v5.62';
+const FLYTAB_VERSION = 'v5.67';
 
 // ========== Diagnostic Logger (ring buffer in localStorage) ==========
 const DiagLog = (() => {
@@ -668,12 +668,31 @@ class FlyTabApp {
                 }
             });
             document.addEventListener('cifp:load-procedure', (e) => {
-                const { insertBefore = [], insertAfter = [], airportWp } = e.detail;
+                const { icao, insertBefore = [], insertAfter = [], airportWp } = e.detail;
                 if (!this.routeEditor) return;
 
                 // Empty route: seed the airport as destination first
                 if (this.routeEditor._waypoints.length === 0 && airportWp) {
                     this.routeEditor._addWaypoint(airportWp, 0);
+                }
+
+                // Stamp approach airport data (field elevation, altLocked) onto the
+                // existing destination waypoint so intermediate airport legs don't
+                // inherit cruise altitude. Find by matching ICAO, fallback to last wp.
+                if (airportWp && icao) {
+                    const wps = this.routeEditor._waypoints;
+                    let destIdx = wps.findIndex(w => w.icao?.toUpperCase() === icao.toUpperCase());
+                    if (destIdx < 0 && wps.length > 0) destIdx = wps.length - 1;
+                    if (destIdx >= 0) {
+                        const existing = wps[destIdx];
+                        wps[destIdx] = {
+                            ...existing,
+                            type: 'APT',
+                            elev_ft: existing.elev_ft ?? airportWp.elev_ft,
+                            alt: existing.elev_ft ?? airportWp.elev_ft ?? airportWp.alt,
+                            altLocked: true,
+                        };
+                    }
                 }
 
                 // Insert IAF, FAF, RW before the destination (last waypoint)

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,7 @@
  * Android Capacitor cockpit app. All data local. Pi for live telemetry only.
  */
 
-const FLYTAB_VERSION = 'v5.60';
+const FLYTAB_VERSION = 'v5.61';
 
 // ========== Diagnostic Logger (ring buffer in localStorage) ==========
 const DiagLog = (() => {
@@ -165,6 +165,9 @@ class FlyTabApp {
 
         // Update NASR age badge after data is loaded
         this._updateNasrBadge();
+
+        // Startup data readiness check — runs in background, shows banner if data is missing/expired
+        setTimeout(() => this._checkDataReadiness(), 3000);
 
         // Long-press version badge to show diagnostic log
         const verBadge = document.getElementById('statusVersion');
@@ -1757,6 +1760,74 @@ class FlyTabApp {
     }
 
     // ========== Toast Notifications ==========
+
+    async _checkDataReadiness() {
+        const LOCAL = 'http://localhost:9090';
+        const issues = [];
+
+        const fetchJson = async (url) => {
+            try {
+                const r = await fetch(url, { cache: 'no-store', signal: AbortSignal.timeout(3000) });
+                return r.ok ? r.json() : null;
+            } catch { return null; }
+        };
+
+        const [nasr, cifp] = await Promise.all([
+            fetchJson(`${LOCAL}/nasr/cycle_info.json`),
+            fetchJson(`${LOCAL}/cifp/cifp_cycle_info.json`),
+        ]);
+
+        if (!nasr) {
+            issues.push({ severity: 'critical', text: 'NASR aeronautical data not on tablet' });
+        } else {
+            const exp = nasr.expiration_date ? new Date(nasr.expiration_date)
+                : new Date(new Date(nasr.effective_date).getTime() + 28 * 86400000);
+            const daysLeft = Math.ceil((exp - Date.now()) / 86400000);
+            if (daysLeft < 0) {
+                issues.push({ severity: 'critical', text: `NASR data expired ${Math.abs(daysLeft)}d ago (cycle ${nasr.effective_date})` });
+            } else if (daysLeft <= 7) {
+                issues.push({ severity: 'warn', text: `NASR data expires in ${daysLeft}d (cycle ${nasr.effective_date})` });
+            }
+        }
+
+        if (!cifp) {
+            issues.push({ severity: 'warn', text: 'CIFP approach procedures not on tablet' });
+        }
+
+        if (issues.length === 0) return;
+
+        const hasCritical = issues.some(i => i.severity === 'critical');
+        const banner = document.createElement('div');
+        banner.id = 'dataReadinessBanner';
+        banner.style.cssText = `
+            position:fixed; top:0; left:0; right:0; z-index:9999;
+            background:${hasCritical ? '#b91c1c' : '#92400e'};
+            color:#fff; font-size:13px; font-weight:600;
+            padding:6px 12px; display:flex; align-items:center; gap:8px;
+            box-shadow:0 2px 6px rgba(0,0,0,0.4);
+        `;
+        banner.innerHTML = `
+            <span style="flex:1">⚠ ${issues.map(i => i.text).join(' · ')}</span>
+            <button style="background:rgba(255,255,255,0.2);border:none;color:#fff;padding:4px 10px;border-radius:4px;font-weight:700;font-size:13px;cursor:pointer;touch-action:manipulation" id="_drFixBtn">Fix Now</button>
+            <button style="background:none;border:none;color:#fff;font-size:18px;cursor:pointer;padding:0 4px;touch-action:manipulation" id="_drDismissBtn">✕</button>
+        `;
+        document.body.appendChild(banner);
+
+        // Offset status bar down to make room
+        const statusBar = document.getElementById('statusBar');
+        const bannerH = banner.offsetHeight || 32;
+        if (statusBar) statusBar.style.marginTop = bannerH + 'px';
+
+        banner.querySelector('#_drFixBtn').addEventListener('click', () => {
+            banner.remove();
+            if (statusBar) statusBar.style.marginTop = '';
+            if (this.dataStatus) this.dataStatus.show();
+        });
+        banner.querySelector('#_drDismissBtn').addEventListener('click', () => {
+            banner.remove();
+            if (statusBar) statusBar.style.marginTop = '';
+        });
+    }
 
     showToast(message, actions = []) {
         const existing = document.querySelector('.toast');

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,7 @@
  * Android Capacitor cockpit app. All data local. Pi for live telemetry only.
  */
 
-const FLYTAB_VERSION = 'v5.59';
+const FLYTAB_VERSION = 'v5.60';
 
 // ========== Diagnostic Logger (ring buffer in localStorage) ==========
 const DiagLog = (() => {

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,7 @@
  * Android Capacitor cockpit app. All data local. Pi for live telemetry only.
  */
 
-const FLYTAB_VERSION = 'v5.61';
+const FLYTAB_VERSION = 'v5.62';
 
 // ========== Diagnostic Logger (ring buffer in localStorage) ==========
 const DiagLog = (() => {
@@ -1800,33 +1800,33 @@ class FlyTabApp {
         const banner = document.createElement('div');
         banner.id = 'dataReadinessBanner';
         banner.style.cssText = `
-            position:fixed; top:0; left:0; right:0; z-index:9999;
             background:${hasCritical ? '#b91c1c' : '#92400e'};
             color:#fff; font-size:13px; font-weight:600;
             padding:6px 12px; display:flex; align-items:center; gap:8px;
-            box-shadow:0 2px 6px rgba(0,0,0,0.4);
+            width:100%; box-sizing:border-box;
         `;
         banner.innerHTML = `
             <span style="flex:1">⚠ ${issues.map(i => i.text).join(' · ')}</span>
             <button style="background:rgba(255,255,255,0.2);border:none;color:#fff;padding:4px 10px;border-radius:4px;font-weight:700;font-size:13px;cursor:pointer;touch-action:manipulation" id="_drFixBtn">Fix Now</button>
             <button style="background:none;border:none;color:#fff;font-size:18px;cursor:pointer;padding:0 4px;touch-action:manipulation" id="_drDismissBtn">✕</button>
         `;
-        document.body.appendChild(banner);
 
-        // Offset status bar down to make room
-        const statusBar = document.getElementById('statusBar');
-        const bannerH = banner.offsetHeight || 32;
-        if (statusBar) statusBar.style.marginTop = bannerH + 'px';
+        // Insert into the flex column after the engine advisory (below status bar, above map)
+        const advisory = document.getElementById('engineAdvisory');
+        const mainContent = document.getElementById('mainContent');
+        if (advisory) {
+            advisory.parentNode.insertBefore(banner, advisory.nextSibling);
+        } else if (mainContent) {
+            mainContent.parentNode.insertBefore(banner, mainContent);
+        } else {
+            document.body.appendChild(banner);
+        }
 
         banner.querySelector('#_drFixBtn').addEventListener('click', () => {
             banner.remove();
-            if (statusBar) statusBar.style.marginTop = '';
             if (this.dataStatus) this.dataStatus.show();
         });
-        banner.querySelector('#_drDismissBtn').addEventListener('click', () => {
-            banner.remove();
-            if (statusBar) statusBar.style.marginTop = '';
-        });
+        banner.querySelector('#_drDismissBtn').addEventListener('click', () => banner.remove());
     }
 
     showToast(message, actions = []) {

--- a/web/cockpit/approach-charts.js
+++ b/web/cockpit/approach-charts.js
@@ -1216,13 +1216,13 @@ class ApproachCharts {
                 return;
             }
 
-            // altitude1 is already in feet — no multiplier needed
+            // altitude1 is stored in tens-of-feet in ARINC 424 (e.g. 300 = 3000 ft, 52 = 520 ft)
             const toWp = s => ({
                 icao: s.fix_id,
                 name: s.fix_id,
                 lat: s.lat,
                 lon: s.lon,
-                alt: s.altitude1 > 0 ? s.altitude1 : null,
+                alt: s.altitude1 > 0 ? s.altitude1 * 10 : null,
                 altLocked: s.altitude1 > 0,
             });
 

--- a/web/cockpit/approach-charts.js
+++ b/web/cockpit/approach-charts.js
@@ -1182,15 +1182,17 @@ class ApproachCharts {
             const resolveCoords = async (id, section) => {
                 if (!this._nasrDb) return null;
                 try {
+                    // RW## pattern: runway threshold — fix_section is null in bundle, detect by id
+                    if (/^RW\d/.test(id) || section === 'PG') {
+                        const r = await this._nasrDb.getAirport(icao);
+                        if (r?.lat) return { lat: r.lat, lon: r.lon };
+                        return null;
+                    }
                     if (section === 'D') {
                         const r = await this._nasrDb.getNavaid(id);
                         if (r?.lat) return { lat: r.lat, lon: r.lon };
                     } else if (section === 'PA') {
                         const r = await this._nasrDb.getAirport(id);
-                        if (r?.lat) return { lat: r.lat, lon: r.lon };
-                    } else if (section === 'PG') {
-                        // Runway — use airport position as proxy
-                        const r = await this._nasrDb.getAirport(icao);
                         if (r?.lat) return { lat: r.lat, lon: r.lon };
                     } else {
                         // PC, EA, unset — fix first, navaid fallback
@@ -1240,10 +1242,19 @@ class ApproachCharts {
                 insertAfter  = steps.slice(rwIdx + 1).map(toWp);
             }
 
-            // Airport waypoint for empty-route case
+            // Airport waypoint for empty-route case.
+            // Lock altitude to field elevation so it doesn't inherit cruise altitude.
             const rwStep = rwIdx >= 0 ? steps[rwIdx] : steps[steps.length - 1];
+            let aptElev = null;
+            if (this._nasrDb) {
+                try {
+                    const aptData = await this._nasrDb.getAirport(icao);
+                    aptElev = aptData?.elev_ft ?? null;
+                } catch {}
+            }
             const airportWp = rwStep
-                ? { icao, name: icao, lat: rwStep.lat, lon: rwStep.lon, type: 'APT' }
+                ? { icao, name: icao, lat: rwStep.lat, lon: rwStep.lon, type: 'APT',
+                    elev_ft: aptElev, alt: aptElev ?? 0, altLocked: true }
                 : null;
 
             document.dispatchEvent(new CustomEvent('cifp:load-procedure', {

--- a/web/cockpit/data-status.js
+++ b/web/cockpit/data-status.js
@@ -1329,8 +1329,16 @@ class DataStatus {
                 setStep('cifp', 'skip', `Current — cycle ${serverCode}`);
             } else {
                 setStep('cifp', 'running', 'Downloading CIFP bundle…');
-                await fetchAndPut('/cifp/cifp_bundle.json',     'cifp/cifp_bundle.json',     'application/json');
-                await fetchAndPut('/cifp/cifp_cycle_info.json', 'cifp/cifp_cycle_info.json', 'application/json');
+                // Use Java-side fetch-zip (same as NASR) to avoid loading 30 MB blob into WebView
+                const cifpZipUrl = encodeURIComponent(`${homeBase}/cifp/cifp.zip`);
+                const cifpResp = await fetch(`${LOCAL}/fetch-zip?url=${cifpZipUrl}`, {
+                    method: 'POST',
+                    signal: AbortSignal.timeout(120000),
+                });
+                if (!cifpResp.ok) {
+                    const msg = await cifpResp.text().catch(() => `HTTP ${cifpResp.status}`);
+                    throw new Error(`fetch-zip failed: ${msg}`);
+                }
                 setStep('cifp', 'ok', `Updated to cycle ${serverCode}`);
             }
         } catch (e) { failStep('cifp', e); }

--- a/web/cockpit/map.js
+++ b/web/cockpit/map.js
@@ -1044,12 +1044,20 @@ class CockpitMap {
             this._legLines.push(line);
         }
 
-        // Waypoint markers — larger radius, tappable for airport popup
+        // Waypoint markers — larger radius, tappable for airport popup, labelled with ICAO
         this._wpMarkers = [];
         waypoints.forEach(wp => {
             const marker = L.circleMarker([wp.lat, wp.lon], {
                 radius: 8, color: '#ff44ff', fillColor: '#ff44ff', fillOpacity: 0.8, weight: 2,
             }).addTo(this.routeLayer);
+
+            const label = wp.icao || wp.name || '';
+            if (label) {
+                marker.bindTooltip(label, {
+                    permanent: true, direction: 'top', offset: [0, -10],
+                    className: 'apt-label apt-label-lg',
+                });
+            }
 
             marker.on('click', () => {
                 if (wp.icao && this._airportPopup) {

--- a/web/cockpit/route-table.js
+++ b/web/cockpit/route-table.js
@@ -262,6 +262,10 @@ class RouteTable {
                 // Destination: show user-set cruise altitude, not field elevation
                 const desSeg = segments.find(s => s.phase === 'DES');
                 wpAlt = wp.alt || desSeg?.altFrom || wp.elev_ft || null;
+            } else if (wp.type === 'APT' && wp.elev_ft != null) {
+                // Intermediate airport (e.g., destination with missed-approach
+                // waypoints after it) — use field elevation, not cruise altitude.
+                wpAlt = wp.elev_ft;
             }
 
             const isApt = wp.type === 'APT' || wp.icao === planDep || wp.icao === planDest;
@@ -1045,12 +1049,15 @@ class RouteTable {
             }
 
             const legDist = wp._legDist || 0;
-            // For the last waypoint (destination): cruise altitude is wp.alt or cruiseAlt,
-            // field elevation (elev_ft) is the descent target — handled by deferred descent below.
-            // For intermediate waypoints: use wp.alt (user-set) or cruiseAlt.
+            // Intermediate airports use field elevation (e.g. destination with a
+            // missed-approach fix after it). Last waypoint uses cruise altitude
+            // with field-elevation descent handled below. Others use wp.alt/cruiseAlt.
+            const isIntermediateApt = !isLast && wp.type === 'APT' && wp.elev_ft != null;
             const wpAlt = isLast
                 ? (wp.alt || cruiseAlt || wp.elev_ft || prevAlt)
-                : (wp.alt || cruiseAlt || prevAlt);
+                : (isIntermediateApt
+                    ? wp.elev_ft
+                    : (wp.alt || cruiseAlt || prevAlt));
             const segments = [];
             let remainingDist = legDist;
 

--- a/web/style.css
+++ b/web/style.css
@@ -1127,10 +1127,11 @@ body {
     font-size: 14px;
     font-weight: 700;
     color: #ff44ff;
-    background: rgba(0,0,0,0.6);
-    border: 1px solid #ff44ff;
+    background: transparent !important;
+    border: none !important;
+    box-shadow: none !important;
     padding: 1px 4px;
-    border-radius: 3px;
+    text-shadow: 0 0 3px #000, 0 0 3px #000;
 }
 
 .rwy-ext-label {


### PR DESCRIPTION
## Summary
- **Approach loading**: full fix sequence with correct ARINC 424 altitudes and NASR coordinate lookup; RW## resolves via airport coords; intermediate destination airport uses field elevation so missed-approach legs plan at the MAP altitude (e.g. KLKR→CORON at 2,200 ft) instead of cruise altitude
- **CIFP download**: fixed altitude multiplier (tens-of-feet encoding) and switched to fetch-zip path so the 30 MB bundle downloads reliably on Android
- **Startup data readiness**: new banner below the status bar warns when NASR or CIFP data is missing or expired
- **Route labels**: magenta ICAO labels restored on route waypoints using the same apt-label treatment as other airports (no white background box)

## Test plan
- [ ] Load KLKR RNAV 28 with HUSTN transition — sequence is HUSTN → SAPSE → WITUR → RW28 → KLKR → CORON with altitudes 2,500 / 2,100 / 520 / field / 2,200
- [ ] Verify KLKR→CORON leg plans as a climb from field elevation to 2,200 ft, not cruise
- [ ] Load approach into both empty route and an existing KTTA→KLKR route — altitudes are correct in both cases
- [ ] Download CIFP on home Wi-Fi via Data & Maps — completes without silent failure
- [ ] Launch with expired NASR or missing CIFP — startup banner appears in the correct position below the status bar
- [ ] Route waypoint labels render as magenta ICAO text with white outline, no background box

🤖 Generated with [Claude Code](https://claude.com/claude-code)