### PR TITLE
fix: align touch handlers with CLAUDE.md canonical pattern (v5.80)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "app.flywhere.flytab"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 579
-        versionName "5.79"
+        versionCode 580
+        versionName "5.80"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,7 @@
  * Android Capacitor cockpit app. All data local. Pi for live telemetry only.
  */
 
-const FLYTAB_VERSION = 'v5.79';
+const FLYTAB_VERSION = 'v5.80';
 
 // ========== Diagnostic Logger (ring buffer in localStorage) ==========
 const DiagLog = (() => {

--- a/web/cockpit/everywhere-search.js
+++ b/web/cockpit/everywhere-search.js
@@ -675,10 +675,12 @@ class EverywhereSearch {
 
     _fastTap(btn, handler) {
         let tapStart = null;
+        let touchHandled = false;
         btn.addEventListener('touchstart', (e) => {
             if (e.touches.length === 1)
                 tapStart = { x: e.touches[0].clientX, y: e.touches[0].clientY, t: Date.now() };
             else tapStart = null;
+            touchHandled = false;
         }, { passive: true });
         btn.addEventListener('touchend', (e) => {
             if (!tapStart || e.changedTouches.length !== 1) { tapStart = null; return; }
@@ -687,9 +689,13 @@ class EverywhereSearch {
             const dy = e.changedTouches[0].clientY - ts.y;
             if (dx*dx + dy*dy > 400) return;
             if (Date.now() - ts.t > 500) return;
+            touchHandled = true;
             handler(e);
         }, { passive: true });
-        btn.addEventListener('click', handler);
+        btn.addEventListener('click', (e) => {
+            if (touchHandled) { touchHandled = false; return; }
+            handler(e);
+        });
     }
 
     _scrollSafeTap(el, handler) {

--- a/web/cockpit/everywhere-search.js
+++ b/web/cockpit/everywhere-search.js
@@ -674,32 +674,41 @@ class EverywhereSearch {
     }
 
     _fastTap(btn, handler) {
-        let fired = false;
+        let tapStart = null;
         btn.addEventListener('touchstart', (e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            fired = true;
+            if (e.touches.length === 1)
+                tapStart = { x: e.touches[0].clientX, y: e.touches[0].clientY, t: Date.now() };
+            else tapStart = null;
+        }, { passive: true });
+        btn.addEventListener('touchend', (e) => {
+            if (!tapStart || e.changedTouches.length !== 1) { tapStart = null; return; }
+            const ts = tapStart; tapStart = null;
+            const dx = e.changedTouches[0].clientX - ts.x;
+            const dy = e.changedTouches[0].clientY - ts.y;
+            if (dx*dx + dy*dy > 400) return;
+            if (Date.now() - ts.t > 500) return;
             handler(e);
-        }, { passive: false });
-        btn.addEventListener('click', (e) => {
-            e.stopPropagation();
-            if (fired) { fired = false; return; }
-            handler(e);
-        });
+        }, { passive: true });
+        btn.addEventListener('click', handler);
     }
 
     _scrollSafeTap(el, handler) {
-        let startY = null;
+        let tapStart = null;
         let touchHandled = false;
         el.addEventListener('touchstart', (e) => {
-            startY = e.touches[0].clientY;
+            if (e.touches.length === 1)
+                tapStart = { x: e.touches[0].clientX, y: e.touches[0].clientY };
+            else tapStart = null;
             touchHandled = false;
         }, { passive: true });
         el.addEventListener('touchend', (e) => {
-            if (startY === null) return;
-            const dy = Math.abs(e.changedTouches[0].clientY - startY);
-            startY = null;
-            if (dy < 8) { touchHandled = true; handler(e); }
+            if (!tapStart || e.changedTouches.length !== 1) { tapStart = null; return; }
+            const ts = tapStart; tapStart = null;
+            const dx = e.changedTouches[0].clientX - ts.x;
+            const dy = e.changedTouches[0].clientY - ts.y;
+            if (dx*dx + dy*dy > 400) return;
+            touchHandled = true;
+            handler(e);
         }, { passive: true });
         el.addEventListener('click', (e) => {
             if (touchHandled) { touchHandled = false; return; }


### PR DESCRIPTION
## Summary

- Replace `passive:false` + `preventDefault()` in `_fastTap` with the CLAUDE.md canonical touchstart/touchend pattern (`passive:true`)
- Update `_scrollSafeTap` drag threshold from linear 8px to `dx*dx + dy*dy > 400` (20px radius), matching CLAUDE.md spec
- Bump version to v5.80

These issues were flagged by the post-merge code review on PR #82.

## Test plan
- [ ] Tap search close button (✕) — closes overlay
- [ ] Tap back button (←) in detail view — returns to results
- [ ] Scroll result list — no accidental taps on scroll
- [ ] Tap a result row — opens detail view

🤖 Generated with [Claude Code](https://claude.ai/code)