### PR TITLE
fix: suppress double-tap waypoint insert + ▲/▼ plan toggle (issue #84)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 FlyTab is an Android cockpit app for experimental aircraft. It runs as a Capacitor web app (vanilla JavaScript, no framework) and communicates with a Raspberry Pi running a Python engine monitor and an unmodified Stratux ADS-B/GPS receiver.
 
+## Build Policy
+
+Run `bash build.sh` automatically after any code change is complete — no need to wait for the user to ask. Always increment `FLYTAB_VERSION` in `web/app.js` before building (build.sh reads it to set versionCode/versionName).
+
 ## Build & Deploy Commands
 
 ```bash

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "app.flywhere.flytab"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 580
-        versionName "5.80"
+        versionCode 582
+        versionName "5.82"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,7 @@
  * Android Capacitor cockpit app. All data local. Pi for live telemetry only.
  */
 
-const FLYTAB_VERSION = 'v5.80';
+const FLYTAB_VERSION = 'v5.81';
 
 // ========== Diagnostic Logger (ring buffer in localStorage) ==========
 const DiagLog = (() => {

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,7 @@
  * Android Capacitor cockpit app. All data local. Pi for live telemetry only.
  */
 
-const FLYTAB_VERSION = 'v5.81';
+const FLYTAB_VERSION = 'v5.82';
 
 // ========== Diagnostic Logger (ring buffer in localStorage) ==========
 const DiagLog = (() => {

--- a/web/cockpit/route-table.js
+++ b/web/cockpit/route-table.js
@@ -1719,6 +1719,7 @@ class RouteTable {
         } else {
             this._bodyEl.style.maxHeight = '0';
         }
+        if (this._toggleBtn) this._toggleBtn.innerHTML = this._expanded ? '&#9660;' : '&#9650;';
         setTimeout(() => {
             this._map?.invalidateSize();
             this._broadcastHeight();
@@ -2027,6 +2028,7 @@ class RouteTable {
             <span class="handle-summary"></span>
             <button class="rt-profile-btn" title="Terrain profile" style="min-width:44px;min-height:44px;font-size:18px;background:none;border:none;color:inherit;cursor:pointer;padding:0 8px">\u26F0</button>
             <button class="route-table-edit-btn">EDIT</button>
+            <button class="rt-toggle-btn" title="Expand/collapse plan">&#9650;</button>
         `;
         // Tap to toggle — no drag, just two states
         let touchStartY = 0;
@@ -2057,6 +2059,9 @@ class RouteTable {
 
         this._profileBtn = this._handleEl.querySelector('.rt-profile-btn');
         this._wireButton(this._profileBtn, () => this._openProfileView());
+
+        this._toggleBtn = this._handleEl.querySelector('.rt-toggle-btn');
+        this._wireButton(this._toggleBtn, () => this.toggle());
 
         // Terrain profile panel (created once, floats above the sheet)
         this._profileView = (typeof RouteProfileView !== 'undefined')

--- a/web/cockpit/vector-map-layers.js
+++ b/web/cockpit/vector-map-layers.js
@@ -72,8 +72,17 @@ class VectorMapLayers {
         // Debounced update on map movement
         this._map.on('moveend zoomend', () => this._scheduleUpdate());
 
-        // Mouse click: use Leaflet's map click (reliable on desktop)
-        this._map.on('click', (e) => this._onMapClick(e));
+        // Mouse click: use Leaflet's map click (reliable on desktop).
+        // Guard: suppress the browser's synthetic click that fires after touchend
+        // (passive touchend cannot call preventDefault, so Android WebView always
+        // generates a click ~300ms later). Without this guard, a single finger tap
+        // calls _onMapClick twice — once from touchend and once from the synthetic
+        // click — which can silently insert the same waypoint twice (issue #84).
+        this._lastTouchTap = 0;
+        this._map.on('click', (e) => {
+            if (Date.now() - this._lastTouchTap < 400) return;
+            this._onMapClick(e);
+        });
 
         // Touch tap: bypass Leaflet entirely. Leaflet's drag handler eats
         // most single-finger taps on iPad (finger jitter > draggable threshold).
@@ -107,6 +116,7 @@ class VectorMapLayers {
                 const rect = container.getBoundingClientRect();
                 const pt = L.point(endX - rect.left, endY - rect.top);
                 const latlng = this._map.containerPointToLatLng(pt);
+                this._lastTouchTap = Date.now();
                 this._onMapClick({ latlng });
             }
         }, { passive: true });

--- a/web/style.css
+++ b/web/style.css
@@ -2370,6 +2370,22 @@ body {
     border-bottom: 1px solid var(--border);
 }
 
+.rt-toggle-btn {
+    min-width: 44px;
+    min-height: 44px;
+    background: none;
+    border: none;
+    color: var(--accent);
+    font-size: 18px;
+    font-weight: 700;
+    cursor: pointer;
+    padding: 0 8px;
+    flex-shrink: 0;
+}
+.rt-toggle-btn:active {
+    opacity: 0.6;
+}
+
 /* Edit mode active state */
 .route-table-editing .route-table-edit-btn,
 .rt-edit-active {


### PR DESCRIPTION
## Summary

- Fixes silent duplicate waypoint insertion caused by touchend + browser synthetic click both firing `_onMapClick` on a single finger tap (issue #84)
- Adds a ▲/▼ expand/collapse button to the right end of the plan view handle bar

## Changes

**`vector-map-layers.js`** — records `_lastTouchTap` timestamp on touchend; `map.on('click')` returns early if called within 400ms of a touch, blocking the browser-synthetic click from double-triggering waypoint insertion.

**`route-table.js`** — adds `.rt-toggle-btn` to the handle bar, wired to `toggle()`, arrow flips with expanded state.

**`style.css`** — styles for `.rt-toggle-btn` (accent color, 44px touch target).

## Test plan
- [ ] Tap an airport on the map while route table is in edit mode — only one waypoint inserted
- [ ] Tap the ▲ button on the collapsed plan bar — plan expands, button becomes ▼
- [ ] Tap ▼ — plan collapses, button becomes ▲
- [ ] Desktop mouse click on map still works normally

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)