### PR TITLE
fix: checklist, layer panel, touch handler unification, state-drift detection (issues #3, #33, #71, #74)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ screenshots/
 .env
 .env.local
 .env.*.local
+.worktrees/

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "app.flywhere.flytab"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 582
-        versionName "5.82"
+        versionCode 583
+        versionName "5.83"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,7 @@
  * Android Capacitor cockpit app. All data local. Pi for live telemetry only.
  */
 
-const FLYTAB_VERSION = 'v5.86';
+const FLYTAB_VERSION = 'v5.87';
 
 // ========== Diagnostic Logger (ring buffer in localStorage) ==========
 const DiagLog = (() => {

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,7 @@
  * Android Capacitor cockpit app. All data local. Pi for live telemetry only.
  */
 
-const FLYTAB_VERSION = 'v5.87';
+const FLYTAB_VERSION = 'v5.88';
 
 // ========== Diagnostic Logger (ring buffer in localStorage) ==========
 const DiagLog = (() => {

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,7 @@
  * Android Capacitor cockpit app. All data local. Pi for live telemetry only.
  */
 
-const FLYTAB_VERSION = 'v5.83';
+const FLYTAB_VERSION = 'v5.84';
 
 // ========== Diagnostic Logger (ring buffer in localStorage) ==========
 const DiagLog = (() => {

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,7 @@
  * Android Capacitor cockpit app. All data local. Pi for live telemetry only.
  */
 
-const FLYTAB_VERSION = 'v5.84';
+const FLYTAB_VERSION = 'v5.85';
 
 // ========== Diagnostic Logger (ring buffer in localStorage) ==========
 const DiagLog = (() => {

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,7 @@
  * Android Capacitor cockpit app. All data local. Pi for live telemetry only.
  */
 
-const FLYTAB_VERSION = 'v5.85';
+const FLYTAB_VERSION = 'v5.86';
 
 // ========== Diagnostic Logger (ring buffer in localStorage) ==========
 const DiagLog = (() => {

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,7 @@
  * Android Capacitor cockpit app. All data local. Pi for live telemetry only.
  */
 
-const FLYTAB_VERSION = 'v5.89';
+const FLYTAB_VERSION = 'v5.90';
 
 // ========== Diagnostic Logger (ring buffer in localStorage) ==========
 const DiagLog = (() => {
@@ -1225,6 +1225,13 @@ class FlyTabApp {
         if (this.cockpitMap && wps.length >= 2) this.cockpitMap.setRoute(wps);
         if (this.rangeCalc) this.rangeCalc.setPlan(normalized);
         if (this.routeEditor) this.routeEditor.loadRoute(normalized);
+
+        if (!skipRouteTable && this.routeTable && this.routeEditor) {
+            const tLen = this.routeTable._waypoints?.length;
+            const eLen = this.routeEditor._waypoints?.length;
+            if (tLen !== eLen)
+                DiagLog.log('plan', `state-drift: routeTable(${tLen}) ≠ routeEditor(${eLen})`);
+        }
 
         if (this.approachCharts) {
             const icaoList = wps.map(wp => wp.icao).filter(Boolean);

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,7 @@
  * Android Capacitor cockpit app. All data local. Pi for live telemetry only.
  */
 
-const FLYTAB_VERSION = 'v5.82';
+const FLYTAB_VERSION = 'v5.83';
 
 // ========== Diagnostic Logger (ring buffer in localStorage) ==========
 const DiagLog = (() => {

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,7 @@
  * Android Capacitor cockpit app. All data local. Pi for live telemetry only.
  */
 
-const FLYTAB_VERSION = 'v5.88';
+const FLYTAB_VERSION = 'v5.89';
 
 // ========== Diagnostic Logger (ring buffer in localStorage) ==========
 const DiagLog = (() => {

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,7 @@
  * Android Capacitor cockpit app. All data local. Pi for live telemetry only.
  */
 
-const FLYTAB_VERSION = 'v5.91';
+const FLYTAB_VERSION = 'v5.92';
 
 // ========== Diagnostic Logger (ring buffer in localStorage) ==========
 const DiagLog = (() => {

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,7 @@
  * Android Capacitor cockpit app. All data local. Pi for live telemetry only.
  */
 
-const FLYTAB_VERSION = 'v5.90';
+const FLYTAB_VERSION = 'v5.91';
 
 // ========== Diagnostic Logger (ring buffer in localStorage) ==========
 const DiagLog = (() => {

--- a/web/checklist.json
+++ b/web/checklist.json
@@ -27,6 +27,7 @@
                 { "title": "Master", "response": "ON" },
                 { "title": "Fuel Computer", "response": "SET" },
                 { "title": "ExpressVPN", "response": "OFF" },
+                { "title": "Tailscale", "response": "OFF" },
                 { "title": "Tablet WIFI", "response": "CONNECTED", "statusSource": "connectivity", "note": "Connect to Stratux hotspot" },
                 { "title": "Engine Data", "response": "RECORDING", "note": "Auto-starts when RPM > 500" },
                 { "title": "Fuel Selector", "response": "FULLEST TANK" }

--- a/web/cockpit/airport-popup.js
+++ b/web/cockpit/airport-popup.js
@@ -142,13 +142,13 @@ class AirportPopup {
         // Wire close button
         const closeBtn = this._panel.querySelector('.apt-panel-close');
         if (closeBtn) {
-            this._wireButton(closeBtn, () => this.close());
+            wireTap(closeBtn, () => this.close());
         }
 
         // Wire action chips
         this._panel.querySelectorAll('.apt-chip[data-action]').forEach(chip => {
             const action = chip.dataset.action;
-            this._wireButton(chip, () => {
+            wireTap(chip, () => {
                 if (action === 'direct-to' && this._onDirectTo) {
                     this._onDirectTo(airport);
                     this.close();
@@ -168,12 +168,12 @@ class AirportPopup {
 
         // Wire frequency rows
         this._panel.querySelectorAll('.freq-row[data-freq]').forEach(row => {
-            this._wireButton(row, () => this._flashFrequency(row.dataset.freq));
+            wireTap(row, () => this._flashFrequency(row.dataset.freq));
         });
 
         // Wire phone rows
         this._panel.querySelectorAll('.ifr-phone, .airport-phone').forEach(phoneEl => {
-            this._wireButton(phoneEl, () => {
+            wireTap(phoneEl, () => {
                 const phone = phoneEl.dataset.phone;
                 navigator.clipboard?.writeText(phone);
                 phoneEl.style.background = '#224433';
@@ -183,7 +183,7 @@ class AirportPopup {
 
         // Wire tabs
         this._panel.querySelectorAll('.apt-tab[data-tab]').forEach(tab => {
-            this._wireButton(tab, () => {
+            wireTap(tab, () => {
                 // APPR tab: open the approach charts picker directly
                 if (tab.dataset.tab === 'appr' && this._approachCharts) {
                     this._approachCharts.showForAirport(airport.icao);
@@ -240,7 +240,7 @@ class AirportPopup {
 
     _wireTopNav() {
         this._panel.querySelectorAll('.apt-topnav-btn[data-topnav]').forEach(btn => {
-            this._wireButton(btn, async () => {
+            wireTap(btn, async () => {
                 const action = btn.dataset.topnav;
                 const airports = this._getRouteAirports?.() || {};
                 if (action === 'dep' && airports.departure?.icao) {
@@ -272,7 +272,7 @@ class AirportPopup {
         const results = this._panel.querySelector('.apt-search-results');
         const closeBtn = this._panel.querySelector('[data-topnav="search-close"]');
 
-        this._wireButton(closeBtn, () => this.close());
+        wireTap(closeBtn, () => this.close());
 
         let debounce = null;
         input.addEventListener('input', () => {
@@ -293,7 +293,7 @@ class AirportPopup {
                             <span class="apt-search-name">${a.name || ''}</span>
                         </div>`).join('');
                     results.querySelectorAll('.apt-search-row').forEach(row => {
-                        this._wireButton(row, () => this.showForAirport(row.dataset.icao));
+                        wireTap(row, () => this.showForAirport(row.dataset.icao));
                     });
                 } catch { results.innerHTML = '<div class="apt-search-empty">Search unavailable</div>'; }
             }, 250);
@@ -584,7 +584,7 @@ class AirportPopup {
         this._panel.classList.add('open');
         this._panelOpen = true;
         const closeBtn = this._panel.querySelector('.apt-panel-close');
-        if (closeBtn) this._wireButton(closeBtn, () => this.close());
+        if (closeBtn) wireTap(closeBtn, () => this.close());
     }
 
     /**
@@ -635,11 +635,11 @@ class AirportPopup {
             const container = this._popup.getElement();
             if (!container) return;
             container.querySelectorAll('.freq-row').forEach(row => {
-                this._wireButton(row, () => this._flashFrequency(row.dataset.freq));
+                wireTap(row, () => this._flashFrequency(row.dataset.freq));
             });
             container.querySelectorAll('.popup-btn').forEach(btn => {
                 const action = btn.dataset.action;
-                this._wireButton(btn, () => {
+                wireTap(btn, () => {
                     if (action === 'direct-to' && this._onDirectTo) {
                         this._onDirectTo({ icao: nav.id, name: nav.name, lat: nav.lat, lon: nav.lon });
                         this.close();
@@ -894,7 +894,7 @@ class AirportPopup {
 
             // Wire plate rows to show viewer
             containerEl.querySelectorAll('.apt-plate-list-row').forEach(row => {
-                this._wireButton(row, () => {
+                wireTap(row, () => {
                     const file = row.dataset.pdf;
                     const name = row.dataset.name;
                     const webpUrl = `${PLATES_BASE}/${icao}/${file.replace(/\.pdf$/i, '.webp')}`;
@@ -1342,52 +1342,18 @@ class AirportPopup {
 
     // ========== Action Binding ==========
 
-    /**
-     * Wire a button with touch-distance detection.
-     * Fires on touchend only if the finger didn't move (not a scroll gesture).
-     * Falls back to click for non-touch devices.
-     */
-    _wireButton(el, action) {
-        let startX = 0, startY = 0, isTap = false;
-        el.addEventListener('touchstart', (e) => {
-            const t = e.touches[0];
-            startX = t.clientX;
-            startY = t.clientY;
-            isTap = true;
-        }, { passive: true });
-        el.addEventListener('touchmove', (e) => {
-            if (!isTap) return;
-            const t = e.touches[0];
-            if (Math.abs(t.clientX - startX) > 10 || Math.abs(t.clientY - startY) > 10) {
-                isTap = false; // finger moved — this is a scroll, not a tap
-            }
-        }, { passive: true });
-        el.addEventListener('touchend', (e) => {
-            if (isTap) {
-                e.stopPropagation();
-                action();
-            }
-            isTap = false;
-        });
-        // Click fallback for non-touch devices
-        el.addEventListener('click', (e) => {
-            e.stopPropagation();
-            action();
-        });
-    }
-
     _bindActions(airport) {
         const container = this._popup.getElement();
         if (!container) return;
 
         // Frequency tap → show large for 3 seconds
         container.querySelectorAll('.freq-row').forEach(row => {
-            this._wireButton(row, () => this._flashFrequency(row.dataset.freq));
+            wireTap(row, () => this._flashFrequency(row.dataset.freq));
         });
 
         // Phone tap → copy (IFR CD phone and airport manager phone)
         container.querySelectorAll('.ifr-phone, .airport-phone').forEach(phoneEl => {
-            this._wireButton(phoneEl, () => {
+            wireTap(phoneEl, () => {
                 const phone = phoneEl.dataset.phone;
                 navigator.clipboard?.writeText(phone);
                 phoneEl.style.background = '#224433';
@@ -1398,7 +1364,7 @@ class AirportPopup {
         // Action buttons
         container.querySelectorAll('.popup-btn').forEach(btn => {
             const action = btn.dataset.action;
-            this._wireButton(btn, () => {
+            wireTap(btn, () => {
                 if (action === 'plates' && this._approachCharts) {
                     this._approachCharts.showForAirport(airport.icao);
                     this.close();

--- a/web/cockpit/approach-charts.js
+++ b/web/cockpit/approach-charts.js
@@ -430,7 +430,7 @@ class ApproachCharts {
             </div>
             <div class="approach-picker-list"></div>
         `;
-        this._wireTap(this._pickerEl.querySelector('[data-action="close-picker"]'), () => this.hide());
+        wireTap(this._pickerEl.querySelector('[data-action="close-picker"]'), () => this.hide());
 
         // Plate viewer overlay
         this._viewerEl = document.createElement('div');
@@ -459,18 +459,18 @@ class ApproachCharts {
         this._panContainer = this._viewerEl.querySelector('.plate-pan-container');
         this._mapBtn = this._viewerEl.querySelector('[data-action="show-on-map"]');
 
-        // Viewer button handlers — use _wireTap for iPad reliability
-        this._wireTap(this._viewerEl.querySelector('[data-action="close-viewer"]'), () => {
+        // Viewer button handlers — use wireTap() for iPad reliability
+        wireTap(this._viewerEl.querySelector('[data-action="close-viewer"]'), () => {
             this._viewerEl.style.display = 'none';
             this._pickerEl.style.display = 'flex';
         });
-        this._wireTap(this._viewerEl.querySelector('[data-action="prev"]'), () => this._navigate(-1));
-        this._wireTap(this._viewerEl.querySelector('[data-action="next"]'), () => this._navigate(1));
-        this._wireTap(this._viewerEl.querySelector('[data-action="fullscreen"]'), () => {
+        wireTap(this._viewerEl.querySelector('[data-action="prev"]'), () => this._navigate(-1));
+        wireTap(this._viewerEl.querySelector('[data-action="next"]'), () => this._navigate(1));
+        wireTap(this._viewerEl.querySelector('[data-action="fullscreen"]'), () => {
             this._viewerEl.requestFullscreen?.();
         });
-        this._wireTap(this._mapBtn, () => this.showOnMap());
-        this._wireTap(this._viewerEl.querySelector('[data-action="load-proc"]'), () => {
+        wireTap(this._mapBtn, () => this.showOnMap());
+        wireTap(this._viewerEl.querySelector('[data-action="load-proc"]'), () => {
             if (this._currentPlate) this._loadCurrentPlateProc(this._currentPlate);
         });
 
@@ -1088,10 +1088,10 @@ class ApproachCharts {
         html += '</div>';
         el.innerHTML = html;
 
-        this._wireTap(el.querySelector('.cifp-proc-close'), () => el.remove());
+        wireTap(el.querySelector('.cifp-proc-close'), () => el.remove());
 
         el.querySelectorAll('.cifp-proc-item').forEach(item => {
-            this._wireTap(item, () => {
+            wireTap(item, () => {
                 const procName = item.dataset.proc;
                 const proc = procs.find(p => p.proc_name === procName);
                 if (proc && proc.transitions.length > 1) {
@@ -1121,9 +1121,9 @@ class ApproachCharts {
         }
         html += '</div>';
         el.innerHTML = html;
-        this._wireTap(el.querySelector('.cifp-proc-close'), () => el.remove());
+        wireTap(el.querySelector('.cifp-proc-close'), () => el.remove());
         el.querySelectorAll('.cifp-proc-item').forEach(item => {
-            this._wireTap(item, () => {
+            wireTap(item, () => {
                 this._loadProcedure(icao, proc.proc_name, item.dataset.trans);
                 el.remove();
             });
@@ -1140,7 +1140,7 @@ class ApproachCharts {
             const item = document.createElement('div');
             item.className = 'cifp-proc-item';
             item.textContent = t;
-            this._wireTap(item, () => {
+            wireTap(item, () => {
                 this._loadProcedure(icao, proc.proc_name, t);
                 parentEl.remove();
             });
@@ -1266,21 +1266,6 @@ class ApproachCharts {
         } catch (err) {
             this._showToast('Failed to load procedure');
         }
-    }
-
-    /** Wire touchstart + click with debounce for iPad reliability */
-    _wireTap(el, handler) {
-        if (!el) return;
-        let touchFired = false;
-        el.addEventListener('touchstart', (e) => {
-            e.stopPropagation();
-            touchFired = true;
-            handler(e);
-            setTimeout(() => { touchFired = false; }, 400);
-        });
-        el.addEventListener('click', (e) => {
-            if (!touchFired) handler(e);
-        });
     }
 
     _showToast(msg) {

--- a/web/cockpit/config-editor.js
+++ b/web/cockpit/config-editor.js
@@ -225,8 +225,8 @@ class ConfigEditor {
         body.innerHTML = sections.join('');
 
         // Bind save/reload — touchstart + click for iPad
-        this._wireTap(body.querySelector('.ce-save-btn'), () => this._save());
-        this._wireTap(body.querySelector('.ce-reload-btn'), () => this._load());
+        wireTap(body.querySelector('.ce-save-btn'), () => this._save());
+        wireTap(body.querySelector('.ce-reload-btn'), () => this._load());
 
         // Track changes
         body.querySelectorAll('input, select').forEach(el => {
@@ -439,21 +439,6 @@ class ConfigEditor {
         return el.value;
     }
 
-    /** Wire touchstart + click with debounce for iPad reliability */
-    _wireTap(el, handler) {
-        if (!el) return;
-        let touchFired = false;
-        el.addEventListener('touchstart', (e) => {
-            e.stopPropagation();
-            touchFired = true;
-            handler(e);
-            setTimeout(() => { touchFired = false; }, 400);
-        });
-        el.addEventListener('click', (e) => {
-            if (!touchFired) handler(e);
-        });
-    }
-
     _setMapControlsVisible(visible) {
         document.querySelectorAll('.leaflet-control-container')
             .forEach(c => c.style.display = visible ? '' : 'none');
@@ -472,7 +457,7 @@ class ConfigEditor {
             </div>
             <div class="config-editor-body"></div>
         `;
-        this._wireTap(this._el.querySelector('.config-editor-close'), () => this.hide());
+        wireTap(this._el.querySelector('.config-editor-close'), () => this.hide());
 
         // Live search — filter cards and section headers
         const searchEl = this._el.querySelector('.ce-search-input');

--- a/web/cockpit/data-status.js
+++ b/web/cockpit/data-status.js
@@ -635,13 +635,13 @@ class DataStatus {
         // Sync All button (in sticky footer)
         const syncAllBtn = stickyFooter ? stickyFooter.querySelector('#dsSyncAllBtn') : body.querySelector('#dsSyncAllBtn');
         if (syncAllBtn && !syncAllBtn.disabled) {
-            this._wireTap(syncAllBtn, () => this._syncAll(syncAllBtn, showProg, updateProg, doneProg));
+            wireTap(syncAllBtn, () => this._syncAll(syncAllBtn, showProg, updateProg, doneProg));
         }
 
         // Reload App Data button (in sticky footer)
         const reloadBtn = stickyFooter ? stickyFooter.querySelector('#dsReloadAppBtn') : body.querySelector('#dsReloadAppBtn');
         if (reloadBtn) {
-            this._wireTap(reloadBtn, async () => {
+            wireTap(reloadBtn, async () => {
                 reloadBtn.disabled = true;
                 reloadBtn.textContent = 'Reloading…';
                 showProg('Reloading app data…', '');
@@ -655,13 +655,13 @@ class DataStatus {
         // Per-section SYNC/DOWNLOAD buttons all trigger _syncAll (skips already-current items)
         for (const id of ['dsNasrBtn', 'dsCifpBtn', 'dsPlatesBtn']) {
             const btn = body.querySelector(`#${id}`);
-            if (btn) this._wireTap(btn, () => this._syncAll(null, showProg, updateProg, doneProg));
+            if (btn) wireTap(btn, () => this._syncAll(null, showProg, updateProg, doneProg));
         }
 
         // NASR RE-DOWNLOAD — force re-download by clearing local cycle stamp
         const nasrRedlBtn = body.querySelector('#dsNasrRedownloadBtn');
         if (nasrRedlBtn) {
-            this._wireTap(nasrRedlBtn, async () => {
+            wireTap(nasrRedlBtn, async () => {
                 await fetch(`${DataStatus.LOCAL_BASE}/nasr/cycle_info.json`, {
                     method: 'PUT', headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ _force: true }),
@@ -673,7 +673,7 @@ class DataStatus {
         // CIFP RE-DOWNLOAD — force re-download by clearing local cycle stamp
         const cifpRedlBtn = body.querySelector('#dsCifpRedownloadBtn');
         if (cifpRedlBtn) {
-            this._wireTap(cifpRedlBtn, async () => {
+            wireTap(cifpRedlBtn, async () => {
                 await fetch(`${DataStatus.LOCAL_BASE}/cifp/cifp_cycle_info.json`, {
                     method: 'PUT', headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ _force: true }),
@@ -685,7 +685,7 @@ class DataStatus {
         // Plates RE-DOWNLOAD — clear sync state then run full sync
         const platesRedlBtn = body.querySelector('#dsPlatesRedownloadBtn');
         if (platesRedlBtn) {
-            this._wireTap(platesRedlBtn, () => {
+            wireTap(platesRedlBtn, () => {
                 localStorage.removeItem('flypi_plates_synced_states');
                 localStorage.removeItem('flypi_plates_cached_at');
                 this._syncAll(null, showProg, updateProg, doneProg);
@@ -694,13 +694,13 @@ class DataStatus {
 
         // MBTiles per-layer download buttons
         body.querySelectorAll('.ds-mbt-dl-btn').forEach(btn => {
-            this._wireTap(btn, () => this._downloadMbtiles(btn.dataset.layer, btn, showProg, doneProg));
+            wireTap(btn, () => this._downloadMbtiles(btn.dataset.layer, btn, showProg, doneProg));
         });
 
         // Terrain SYNC button
         const terrainSyncBtn = body.querySelector('.ds-terrain-sync-btn');
         if (terrainSyncBtn) {
-            this._wireTap(terrainSyncBtn, async () => {
+            wireTap(terrainSyncBtn, async () => {
                 const homeBase = this._resolvedBase;
                 if (!homeBase) return;
                 const prevDone = body.querySelector('#dsSyncDoneBtn');
@@ -718,7 +718,7 @@ class DataStatus {
         // Terrain RE-DOWNLOAD — just re-runs full sync (PUT overwrites existing tiles)
         const terrainRedlBtn = body.querySelector('.ds-terrain-redownload-btn');
         if (terrainRedlBtn) {
-            this._wireTap(terrainRedlBtn, async () => {
+            wireTap(terrainRedlBtn, async () => {
                 const homeBase = this._resolvedBase;
                 if (!homeBase) return;
                 const prevDone = body.querySelector('#dsSyncDoneBtn');
@@ -737,7 +737,7 @@ class DataStatus {
         const suppToggle = body.querySelector('#dsSuppToggle');
         const suppContent = body.querySelector('#dsSuppContent');
         if (suppToggle && suppContent) {
-            this._wireTap(suppToggle, () => {
+            wireTap(suppToggle, () => {
                 const hidden = suppContent.style.display === 'none';
                 suppContent.style.display = hidden ? '' : 'none';
             });
@@ -877,7 +877,7 @@ class DataStatus {
         const loadBtn = body.querySelector('#dsLoadServerBtn');
         const serverZips = body.querySelector('#dsServerZips');
         if (loadBtn) {
-            this._wireTap(loadBtn, async () => {
+            wireTap(loadBtn, async () => {
                 loadBtn.disabled = true; loadBtn.textContent = '…';
                 serverZips.innerHTML = '';
                 try {
@@ -894,7 +894,7 @@ class DataStatus {
                             row.style.marginTop = '6px';
                             row.innerHTML = `<span class="ds-cache-info"><span class="ds-cache-name">${p.id}</span><span class="ds-cache-sub">${p.size_mb} MB</span></span><button class="ds-cache-btn">Import</button>`;
                             const btn = row.querySelector('button');
-                            this._wireTap(btn, async () => {
+                            wireTap(btn, async () => {
                                 if (this._cacheRunning) return;
                                 btn.disabled = true; btn.textContent = 'Downloading…';
                                 showProg('Downloading ' + p.id + '.zip…');
@@ -921,7 +921,7 @@ class DataStatus {
         const zipInput = body.querySelector('#dsZipInput');
         const importBtn = body.querySelector('#dsImportZipBtn');
         if (importBtn && zipInput) {
-            this._wireTap(importBtn, () => zipInput.click());
+            wireTap(importBtn, () => zipInput.click());
             zipInput.addEventListener('change', () => {
                 if (zipInput.files[0]) { this._importZip(zipInput.files[0], showProg, updateProg, doneProg); zipInput.value = ''; }
             });
@@ -931,13 +931,13 @@ class DataStatus {
         const routeBtn = body.querySelector('#dsCacheRouteBtn');
         if (routeBtn) {
             const bbox = (() => { try { return JSON.parse(localStorage.getItem('flypi_route_bbox') || 'null'); } catch { return null; } })();
-            if (bbox) this._wireTap(routeBtn, () => this._cacheRegion(bbox, routeBtn, showProg, updateProg, doneProg));
+            if (bbox) wireTap(routeBtn, () => this._cacheRegion(bbox, routeBtn, showProg, updateProg, doneProg));
         }
 
         // Route Weather button — triggers flywhere.app weather fetch for active plan
         const routeWxBtn = body.querySelector('#dsCacheRouteWxBtn');
         if (routeWxBtn) {
-            this._wireTap(routeWxBtn, async () => {
+            wireTap(routeWxBtn, async () => {
                 const app = window.app;
                 if (!app) return;
                 const plan = app.routeTable?._waypoints?.length
@@ -968,7 +968,7 @@ class DataStatus {
         body.querySelectorAll('.ds-cache-btn[data-region]').forEach(btn => {
             const region = DataStatus.REGIONS.find(r => r.id === btn.dataset.region);
             if (!region) return;
-            this._wireTap(btn, () => this._cacheRegion(region, btn, showProg, updateProg, doneProg));
+            wireTap(btn, () => this._cacheRegion(region, btn, showProg, updateProg, doneProg));
         });
 
         // Approach Plates — Download from home server
@@ -976,7 +976,7 @@ class DataStatus {
         const platesInput  = body.querySelector('#dsPlateIcaoInput');
         const dlPlatesBtn  = body.querySelector('#dsDownloadPlatesBtn');
         if (dlPlatesBtn && platesInput) {
-            this._wireTap(dlPlatesBtn, async () => {
+            wireTap(dlPlatesBtn, async () => {
                 const raw = platesInput.value.trim();
                 if (!raw) { platesStatus.textContent = 'Enter at least one ICAO.'; return; }
                 const icaos = raw.split(/[\s,]+/).filter(Boolean).map(s => s.toUpperCase()).join(',');
@@ -1033,7 +1033,7 @@ class DataStatus {
         const platesZipInput = body.querySelector('#dsPlatesZipInput');
         const importPlatesBtn = body.querySelector('#dsImportPlatesBtn');
         if (importPlatesBtn && platesZipInput) {
-            this._wireTap(importPlatesBtn, () => platesZipInput.click());
+            wireTap(importPlatesBtn, () => platesZipInput.click());
             platesZipInput.addEventListener('change', () => {
                 if (platesZipInput.files[0]) {
                     this._importPlatesZip(platesZipInput.files[0], showProg, updateProg, doneProg);
@@ -1460,7 +1460,7 @@ class DataStatus {
     /** Wire the "Done — Refresh" button that appears after _syncAll completes. */
     _wireDoneBtn() {
         const btn = this._el.querySelector('#dsSyncDoneBtn');
-        if (btn) this._wireTap(btn, async () => {
+        if (btn) wireTap(btn, async () => {
             await window.app?._updateNasrBadge?.();
             this._refresh();
         });
@@ -1602,20 +1602,6 @@ class DataStatus {
 
     // ── Utilities ─────────────────────────────────────────────────────────────
 
-    _wireTap(el, handler) {
-        if (!el) return;
-        let touchFired = false;
-        el.addEventListener('touchstart', (e) => {
-            e.stopPropagation();
-            touchFired = true;
-            handler(e);
-            setTimeout(() => { touchFired = false; }, 400);
-        });
-        el.addEventListener('click', (e) => {
-            if (!touchFired) handler(e);
-        });
-    }
-
     _setMapControlsVisible(visible) {
         const containers = document.querySelectorAll('.leaflet-control-container');
         containers.forEach(c => c.style.display = visible ? '' : 'none');
@@ -1639,7 +1625,7 @@ class DataStatus {
             <div class="data-status-body"></div>
             <div class="ds-sticky-footer" id="dsStickyFooter"></div>
         `;
-        this._wireTap(this._el.querySelector('.data-status-close'), () => this.hide());
+        wireTap(this._el.querySelector('.data-status-close'), () => this.hide());
         this._parentEl.appendChild(this._el);
     }
 }

--- a/web/cockpit/engine-page.js
+++ b/web/cockpit/engine-page.js
@@ -224,13 +224,13 @@ class EnginePage {
         this._tick();
 
         // Wire close button — touchstart + click for iPad
-        this._wireTap(this._el.querySelector('#ep-close'), () => this.hide());
+        wireTap(this._el.querySelector('#ep-close'), () => this.hide());
 
         // Wire capture stop button
-        this._wireTap(this._el.querySelector('#ep-capture-stop'), () => this._stopCapture());
+        wireTap(this._el.querySelector('#ep-capture-stop'), () => this._stopCapture());
 
         // Wire sticky-valve dismiss
-        this._wireTap(this._el.querySelector('#ep-sticky-dismiss'), () => {
+        wireTap(this._el.querySelector('#ep-sticky-dismiss'), () => {
             this._stickyDismissed = true;
             this._el.querySelector('#ep-sticky-banner').style.display = 'none';
         });
@@ -320,21 +320,6 @@ class EnginePage {
     }
 
     get visible() { return this._visible; }
-
-    /** Wire touchstart + click with debounce for iPad reliability */
-    _wireTap(el, handler) {
-        if (!el) return;
-        let touchFired = false;
-        el.addEventListener('touchstart', (e) => {
-            e.stopPropagation();
-            touchFired = true;
-            handler(e);
-            setTimeout(() => { touchFired = false; }, 400);
-        });
-        el.addEventListener('click', (e) => {
-            if (!touchFired) handler(e);
-        });
-    }
 
     /* ------------------------------------------------------------------
      * Config
@@ -873,7 +858,7 @@ class EnginePage {
                     dlBtn.style.color = 'var(--status-ok)';
                     dlBtn.style.borderColor = 'var(--status-ok)';
                     this._dom.captureStatus.parentNode.insertBefore(dlBtn, this._dom.captureStop);
-                    this._wireTap(dlBtn, () => {
+                    wireTap(dlBtn, () => {
                         window.flightSync.downloadToiPad(fname);
                         dlBtn.textContent = '✓ Saved';
                         dlBtn.disabled = true;

--- a/web/cockpit/everywhere-search.js
+++ b/web/cockpit/everywhere-search.js
@@ -84,7 +84,7 @@ class EverywhereSearch {
         const closeBtn = document.createElement('button');
         closeBtn.className = 'btn-close';
         closeBtn.innerHTML = '&#x2715;';
-        this._fastTap(closeBtn, () => this.hide());
+        wireTap(closeBtn, () => this.hide());
 
         header.appendChild(input);
         header.appendChild(closeBtn);
@@ -320,7 +320,7 @@ class EverywhereSearch {
         row.appendChild(middle);
         row.appendChild(right);
 
-        this._scrollSafeTap(row, () => this._showDetail(entity, type));
+        wireTap(row, () => this._showDetail(entity, type));
 
         return row;
     }
@@ -340,7 +340,7 @@ class EverywhereSearch {
         const backBtn = document.createElement('button');
         backBtn.innerHTML = '&#x2190;';
         backBtn.style.cssText = 'min-width:var(--touch-min,56px);min-height:var(--touch-min,56px);font-size:26px;font-weight:700;background:transparent;border:none;color:var(--accent);flex-shrink:0;cursor:pointer;';
-        this._fastTap(backBtn, () => this._hideDetail());
+        wireTap(backBtn, () => this._hideDetail());
 
         const badge = document.createElement('span');
         badge.textContent = type;
@@ -363,7 +363,7 @@ class EverywhereSearch {
         const closeBtn = document.createElement('button');
         closeBtn.className = 'btn-close';
         closeBtn.innerHTML = '&#x2715;';
-        this._fastTap(closeBtn, () => this.hide());
+        wireTap(closeBtn, () => this.hide());
 
         header.appendChild(backBtn);
         header.appendChild(badge);
@@ -617,7 +617,7 @@ class EverywhereSearch {
             (primary
                 ? 'background:var(--accent);color:var(--text-on-accent);'
                 : 'background:transparent;color:var(--accent);');
-        this._fastTap(btn, handler);
+        wireTap(btn, handler);
         return btn;
     }
 
@@ -673,52 +673,4 @@ class EverywhereSearch {
         return !!(trip?.waypoints?.length >= 2);
     }
 
-    _fastTap(btn, handler) {
-        let tapStart = null;
-        let touchHandled = false;
-        btn.addEventListener('touchstart', (e) => {
-            if (e.touches.length === 1)
-                tapStart = { x: e.touches[0].clientX, y: e.touches[0].clientY, t: Date.now() };
-            else tapStart = null;
-            touchHandled = false;
-        }, { passive: true });
-        btn.addEventListener('touchend', (e) => {
-            if (!tapStart || e.changedTouches.length !== 1) { tapStart = null; return; }
-            const ts = tapStart; tapStart = null;
-            const dx = e.changedTouches[0].clientX - ts.x;
-            const dy = e.changedTouches[0].clientY - ts.y;
-            if (dx*dx + dy*dy > 400) return;
-            if (Date.now() - ts.t > 500) return;
-            touchHandled = true;
-            handler(e);
-        }, { passive: true });
-        btn.addEventListener('click', (e) => {
-            if (touchHandled) { touchHandled = false; return; }
-            handler(e);
-        });
-    }
-
-    _scrollSafeTap(el, handler) {
-        let tapStart = null;
-        let touchHandled = false;
-        el.addEventListener('touchstart', (e) => {
-            if (e.touches.length === 1)
-                tapStart = { x: e.touches[0].clientX, y: e.touches[0].clientY };
-            else tapStart = null;
-            touchHandled = false;
-        }, { passive: true });
-        el.addEventListener('touchend', (e) => {
-            if (!tapStart || e.changedTouches.length !== 1) { tapStart = null; return; }
-            const ts = tapStart; tapStart = null;
-            const dx = e.changedTouches[0].clientX - ts.x;
-            const dy = e.changedTouches[0].clientY - ts.y;
-            if (dx*dx + dy*dy > 400) return;
-            touchHandled = true;
-            handler(e);
-        }, { passive: true });
-        el.addEventListener('click', (e) => {
-            if (touchHandled) { touchHandled = false; return; }
-            handler(e);
-        });
-    }
 }

--- a/web/cockpit/fisb-status.js
+++ b/web/cockpit/fisb-status.js
@@ -72,7 +72,7 @@ class FisbStatus {
             </div>
         `;
 
-        this._el.querySelector('.fisb-close').addEventListener('click', () => this.hide());
+        wireTap(this._el.querySelector('.fisb-close'), () => this.hide());
         // Block touch events from reaching map underneath
         this._el.addEventListener('touchstart', (e) => e.stopPropagation(), { passive: true });
 

--- a/web/cockpit/fuel-overlay.js
+++ b/web/cockpit/fuel-overlay.js
@@ -227,7 +227,7 @@ class FuelOverlay {
         };
 
         // Wire close
-        this._wireTap(this._el.querySelector('#fo-close'), () => this.hide());
+        wireTap(this._el.querySelector('#fo-close'), () => this.hide());
 
         // Wire left tank controls
         this._dom.leftSlider.addEventListener('input', (e) => {
@@ -241,13 +241,13 @@ class FuelOverlay {
             this._dom.leftSlider.value = this._leftTic;
             this._updateDisplay();
         });
-        this._wireTap(this._el.querySelector('#fo-left-minus'), () => {
+        wireTap(this._el.querySelector('#fo-left-minus'), () => {
             this._leftTic = Math.max(0, Math.round((this._leftTic - this._ticStep) / this._ticStep) * this._ticStep);
             this._dom.leftSlider.value = this._leftTic;
             this._dom.leftInput.value = this._leftTic;
             this._updateDisplay();
         });
-        this._wireTap(this._el.querySelector('#fo-left-plus'), () => {
+        wireTap(this._el.querySelector('#fo-left-plus'), () => {
             this._leftTic = Math.min(this._maxTic, Math.round((this._leftTic + this._ticStep) / this._ticStep) * this._ticStep);
             this._dom.leftSlider.value = this._leftTic;
             this._dom.leftInput.value = this._leftTic;
@@ -266,13 +266,13 @@ class FuelOverlay {
             this._dom.rightSlider.value = this._rightTic;
             this._updateDisplay();
         });
-        this._wireTap(this._el.querySelector('#fo-right-minus'), () => {
+        wireTap(this._el.querySelector('#fo-right-minus'), () => {
             this._rightTic = Math.max(0, Math.round((this._rightTic - this._ticStep) / this._ticStep) * this._ticStep);
             this._dom.rightSlider.value = this._rightTic;
             this._dom.rightInput.value = this._rightTic;
             this._updateDisplay();
         });
-        this._wireTap(this._el.querySelector('#fo-right-plus'), () => {
+        wireTap(this._el.querySelector('#fo-right-plus'), () => {
             this._rightTic = Math.min(this._maxTic, Math.round((this._rightTic + this._ticStep) / this._ticStep) * this._ticStep);
             this._dom.rightSlider.value = this._rightTic;
             this._dom.rightInput.value = this._rightTic;
@@ -280,7 +280,7 @@ class FuelOverlay {
         });
 
         // Wire manual override
-        this._wireTap(this._el.querySelector('#fo-manual-set'), () => {
+        wireTap(this._el.querySelector('#fo-manual-set'), () => {
             const val = parseFloat(this._dom.manualInput.value);
             if (val > 0) {
                 FuelState.setManualOverride(val);
@@ -288,7 +288,7 @@ class FuelOverlay {
                 window.dispatchEvent(new CustomEvent('fuelstate:changed'));
             }
         });
-        this._wireTap(this._el.querySelector('#fo-manual-clear'), () => {
+        wireTap(this._el.querySelector('#fo-manual-clear'), () => {
             FuelState.clearManualOverride();
             this._dom.manualInput.value = '';
             this._updateSourceDisplay();
@@ -296,12 +296,12 @@ class FuelOverlay {
         });
 
         // Wire apply
-        this._wireTap(this._el.querySelector('#fo-apply'), () => {
+        wireTap(this._el.querySelector('#fo-apply'), () => {
             this._applyMeasurement();
         });
 
         // Wire fuel-add record button
-        this._wireTap(this._el.querySelector('#fo-add-record'), () => {
+        wireTap(this._el.querySelector('#fo-add-record'), () => {
             this._recordFuelStop();
         });
     }
@@ -565,21 +565,6 @@ class FuelOverlay {
         el.className = 'fo-add-status fo-add-status-' + (type || 'ok');
     }
 
-    /** Wire touchstart + click with debounce for iPad reliability */
-    _wireTap(el, handler) {
-        if (!el) return;
-        let touchFired = false;
-        el.addEventListener('touchstart', (e) => {
-            e.stopPropagation();
-            touchFired = true;
-            handler(e);
-            setTimeout(() => { touchFired = false; }, 400);
-        });
-        el.addEventListener('click', (e) => {
-            if (!touchFired) handler(e);
-        });
-    }
-
     _loadHistory() {
         try { return JSON.parse(localStorage.getItem('flypi_fuel_history') || '[]'); }
         catch (_) { return []; }
@@ -623,10 +608,10 @@ class FuelOverlay {
                     <button class="fo-hist-btn fo-hist-del" title="Delete">✕</button>
                 </td>`;
 
-            this._wireTap(tr.querySelector('.fo-hist-del'), () => {
+            wireTap(tr.querySelector('.fo-hist-del'), () => {
                 this._deleteHistoryEntry(origIdx);
             });
-            this._wireTap(tr.querySelector('.fo-hist-edit'), () => {
+            wireTap(tr.querySelector('.fo-hist-edit'), () => {
                 this._editHistoryRow(origIdx, tr);
             });
 
@@ -665,7 +650,7 @@ class FuelOverlay {
                 <button class="fo-hist-btn fo-hist-cancel">✕</button>
             </td>`;
 
-        this._wireTap(tr.querySelector('.fo-hist-save'), () => {
+        wireTap(tr.querySelector('.fo-hist-save'), () => {
             const newTic = parseFloat(tr.querySelector(`#fo-hist-tic-${origIdx}`).value);
             const newEdm = parseFloat(tr.querySelector(`#fo-hist-edm-${origIdx}`).value);
             if (!isNaN(newTic)) m.total_gal = newTic;
@@ -675,7 +660,7 @@ class FuelOverlay {
             this._renderHistory();
             this._renderKFactor();
         });
-        this._wireTap(tr.querySelector('.fo-hist-cancel'), () => {
+        wireTap(tr.querySelector('.fo-hist-cancel'), () => {
             this._renderHistory();
         });
     }

--- a/web/cockpit/fuel-tanks.js
+++ b/web/cockpit/fuel-tanks.js
@@ -197,11 +197,11 @@ class FuelTanksDisplay {
 
         this._makeDraggable();
 
-        this._wireTap(this._dom.badgeL, () => this._onBadgeTap('L'));
-        this._wireTap(this._dom.badgeR, () => this._onBadgeTap('R'));
+        wireTap(this._dom.badgeL, () => this._onBadgeTap('L'));
+        wireTap(this._dom.badgeR, () => this._onBadgeTap('R'));
 
         this._dom.selRow.querySelectorAll('.ftw-sel-btn').forEach(btn => {
-            this._wireTap(btn, () => {
+            wireTap(btn, () => {
                 this._initSelectedTank = btn.dataset.tank;
                 this._dom.selRow.querySelectorAll('.ftw-sel-btn').forEach(b =>
                     b.classList.toggle('ftw-sel-active', b.dataset.tank === this._initSelectedTank)
@@ -209,10 +209,10 @@ class FuelTanksDisplay {
             });
         });
 
-        this._wireTap(this._dom.initOk, () => this._applyInit());
-        this._wireTap(this._dom.initCancel, () => { this._dom.initPanel.style.display = 'none'; });
-        this._wireTap(this._dom.confirmYes, () => this._dismissConfirm(false));
-        this._wireTap(this._dom.confirmSwitch, () => this._dismissConfirm(true));
+        wireTap(this._dom.initOk, () => this._applyInit());
+        wireTap(this._dom.initCancel, () => { this._dom.initPanel.style.display = 'none'; });
+        wireTap(this._dom.confirmYes, () => this._dismissConfirm(false));
+        wireTap(this._dom.confirmSwitch, () => this._dismissConfirm(true));
     }
 
     /* ------------------------------------------------------------------
@@ -484,20 +484,4 @@ class FuelTanksDisplay {
         this._dragHandle = handle;
     }
 
-    /* ------------------------------------------------------------------
-     * Touch handling (same pattern as fuel-overlay)
-     * ----------------------------------------------------------------*/
-    _wireTap(el, handler) {
-        if (!el) return;
-        let touchFired = false;
-        el.addEventListener('touchstart', (e) => {
-            e.stopPropagation();
-            touchFired = true;
-            handler(e);
-            setTimeout(() => { touchFired = false; }, 400);
-        });
-        el.addEventListener('click', (e) => {
-            if (!touchFired) handler(e);
-        });
-    }
 }

--- a/web/cockpit/layer-panel.js
+++ b/web/cockpit/layer-panel.js
@@ -68,7 +68,7 @@ class LayerPanel {
 
         // Wire accordion headers
         this._panel.querySelectorAll('.lp-accordion-header[data-acc]').forEach(btn => {
-            this._fastTap(btn, () => {
+            wireTap(btn, () => {
                 const acc = this._panel.querySelector(`#${btn.dataset.acc}`);
                 if (!acc) return;
                 const open = acc.classList.toggle('open');
@@ -79,12 +79,12 @@ class LayerPanel {
         // Wire close button
         const closeBtn = this._panel.querySelector('.layer-panel-close');
         if (closeBtn) {
-            this._fastTap(closeBtn, () => this.close());
+            wireTap(closeBtn, () => this.close());
         }
 
         // Wire base chart radio buttons
         this._panel.querySelectorAll('.lp-radio-btn[data-layer]').forEach(btn => {
-            this._fastTap(btn, () => {
+            wireTap(btn, () => {
                 const layer = btn.dataset.layer;
                 this._cockpitMap.switchBaseLayer(layer);
                 this._panel.querySelectorAll('.lp-radio-btn[data-layer]').forEach(b => {
@@ -264,12 +264,12 @@ class LayerPanel {
         // Wire cancel button
         const cancelBtn = this._panel.querySelector('#lpCancelDownload');
         if (cancelBtn) {
-            this._fastTap(cancelBtn, () => { this._cancelPrefetch = true; });
+            wireTap(cancelBtn, () => { this._cancelPrefetch = true; });
         }
 
         // Wire region Cache buttons
         this._panel.querySelectorAll('.lp-cache-btn[data-region]').forEach(btn => {
-            this._fastTap(btn, () => {
+            wireTap(btn, () => {
                 const region = LayerPanel.REGIONS.find(r => r.id === btn.dataset.region);
                 if (region && !this._prefetchRunning) this._cacheRegion(region, btn);
             });
@@ -278,7 +278,7 @@ class LayerPanel {
         // Wire Route Area cache button
         const routeBtn = this._panel.querySelector('#lpRouteCacheBtn');
         if (routeBtn) {
-            this._fastTap(routeBtn, () => {
+            wireTap(routeBtn, () => {
                 if (this._prefetchRunning) return;
                 const bbox = this._getRouteBbox?.();
                 if (!bbox) return;
@@ -290,7 +290,7 @@ class LayerPanel {
         const zipInput = this._panel.querySelector('#lpZipInput');
         const importBtn = this._panel.querySelector('#lpImportZipBtn');
         if (importBtn && zipInput) {
-            this._fastTap(importBtn, () => zipInput.click());
+            wireTap(importBtn, () => zipInput.click());
             zipInput.addEventListener('change', () => {
                 if (zipInput.files && zipInput.files[0]) {
                     this._importZip(zipInput.files[0]);
@@ -303,7 +303,7 @@ class LayerPanel {
         const dlZipsBtn = this._panel.querySelector('#lpDownloadZipsBtn');
         const serverZipsEl = this._panel.querySelector('#lpServerZips');
         if (dlZipsBtn && serverZipsEl) {
-            this._fastTap(dlZipsBtn, async () => {
+            wireTap(dlZipsBtn, async () => {
                 dlZipsBtn.disabled = true;
                 dlZipsBtn.textContent = 'Checking server…';
                 serverZipsEl.style.display = 'none';
@@ -326,7 +326,7 @@ class LayerPanel {
                                 <button class="lp-cache-btn" data-zip-url="${base + p.url}" data-zip-id="${p.id}">Import</button>
                             </div>`).join('');
                         serverZipsEl.querySelectorAll('.lp-cache-btn[data-zip-url]').forEach(btn => {
-                            this._fastTap(btn, async () => {
+                            wireTap(btn, async () => {
                                 if (this._prefetchRunning) return;
                                 btn.disabled = true;
                                 btn.textContent = 'Downloading…';
@@ -361,7 +361,7 @@ class LayerPanel {
         // Wire Data & Maps button
         const dataMapsBtn = this._panel.querySelector('#lpOpenDataMaps');
         if (dataMapsBtn) {
-            this._fastTap(dataMapsBtn, () => {
+            wireTap(dataMapsBtn, () => {
                 this.close();
                 window.app?.dataStatus?.show();
             });
@@ -802,19 +802,4 @@ class LayerPanel {
         }
     }
 
-    /** Reliable tap handler for both touch and mouse */
-    _fastTap(btn, handler) {
-        let touchFired = false;
-        btn.addEventListener('touchstart', (e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            touchFired = true;
-            handler(e);
-        }, { passive: false });
-        btn.addEventListener('click', (e) => {
-            e.stopPropagation();
-            if (touchFired) { touchFired = false; return; }
-            handler(e);
-        });
-    }
 }

--- a/web/cockpit/logbook.js
+++ b/web/cockpit/logbook.js
@@ -92,13 +92,13 @@ class Logbook {
         closeBtn.addEventListener('touchend', (e) => { e.preventDefault(); this.hide(); });
 
         const addBtn = this._el.querySelector('.logbook-add-btn');
-        this._wireButton(addBtn, () => {
+        wireTap(addBtn, () => {
             if (this._activeTab === 'oil') this._showOilForm(null);
             else if (this._activeTab !== 'ml') this._showForm(null);
         });
 
         const syncBtn = this._el.querySelector('.logbook-sync-btn');
-        this._wireButton(syncBtn, () => {
+        wireTap(syncBtn, () => {
             syncBtn.textContent = '...';
             this.syncWhenOnline().finally(() => {
                 syncBtn.textContent = 'SYNC';
@@ -108,7 +108,7 @@ class Logbook {
 
         // Tab switching
         this._el.querySelectorAll('.logbook-tab').forEach(tab => {
-            this._wireButton(tab, () => {
+            wireTap(tab, () => {
                 this._el.querySelectorAll('.logbook-tab').forEach(t => t.classList.remove('active'));
                 tab.classList.add('active');
                 this._activeTab = tab.dataset.tab;
@@ -189,7 +189,7 @@ class Logbook {
 
         // Wire edit buttons
         this._body.querySelectorAll('.logbook-edit-btn').forEach(btn => {
-            this._wireButton(btn, () => {
+            wireTap(btn, () => {
                 const entry = entries.find(e => e.id === btn.dataset.id);
                 if (entry) this._showForm(entry);
             });
@@ -199,7 +199,7 @@ class Logbook {
         this._body.querySelectorAll('.logbook-delete-btn').forEach(btn => {
             let confirmPending = false;
             let confirmTimer = null;
-            this._wireButton(btn, async () => {
+            wireTap(btn, async () => {
                 if (confirmPending) {
                     // Second tap — delete
                     clearTimeout(confirmTimer);
@@ -335,12 +335,12 @@ class Logbook {
         // Wire cancel
         const cancelBtns = overlay.querySelectorAll('.logbook-form-cancel, .logbook-form-cancel-btn');
         cancelBtns.forEach(btn => {
-            this._wireButton(btn, () => overlay.remove());
+            wireTap(btn, () => overlay.remove());
         });
 
         // Wire save
         const saveBtn = overlay.querySelector('.logbook-form-save');
-        this._wireButton(saveBtn, async () => {
+        wireTap(saveBtn, async () => {
             saveBtn.textContent = '...';
             saveBtn.disabled = true;
             try {
@@ -1182,7 +1182,7 @@ class Logbook {
         this._body.querySelectorAll('.logbook-delete-btn').forEach(btn => {
             let confirmPending = false;
             let confirmTimer = null;
-            this._wireButton(btn, async () => {
+            wireTap(btn, async () => {
                 if (confirmPending) {
                     clearTimeout(confirmTimer);
                     await this._deleteOilEvent(btn.dataset.id);
@@ -1299,7 +1299,7 @@ class Logbook {
 
         // Wire per-entry export (loads from IDB)
         this._body.querySelectorAll('.lb-ml-export-btn').forEach(btn => {
-            this._wireButton(btn, async () => {
+            wireTap(btn, async () => {
                 const entryId = btn.dataset.entryId;
                 try {
                     const db = await this._openIdb();
@@ -1385,11 +1385,11 @@ class Logbook {
         this._el.appendChild(overlay);
 
         overlay.querySelectorAll('.logbook-form-cancel, .logbook-form-cancel-btn').forEach(btn => {
-            this._wireButton(btn, () => overlay.remove());
+            wireTap(btn, () => overlay.remove());
         });
 
         const saveBtn = overlay.querySelector('.logbook-form-save');
-        this._wireButton(saveBtn, async () => {
+        wireTap(saveBtn, async () => {
             saveBtn.textContent = '...';
             saveBtn.disabled = true;
             try {
@@ -1590,23 +1590,6 @@ class Logbook {
             tx.objectStore(Logbook.IDB_STORE).put(entry);
             tx.oncomplete = () => { db.close(); resolve(); };
             tx.onerror = () => { db.close(); reject(tx.error); };
-        });
-    }
-
-    // ========== Internal: Touch Button Wiring ==========
-
-    _wireButton(el, action) {
-        let touchFired = false;
-        el.addEventListener('touchstart', (e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            touchFired = true;
-            action();
-        }, { passive: false });
-        el.addEventListener('click', (e) => {
-            e.stopPropagation();
-            if (touchFired) { touchFired = false; return; }
-            action();
         });
     }
 

--- a/web/cockpit/map.js
+++ b/web/cockpit/map.js
@@ -1261,31 +1261,6 @@ class CockpitMap {
 
     // ========== Map Controls ==========
 
-    /**
-     * Wire a button for instant tap response on touch devices.
-     * Uses touchend (fires immediately, no 300ms delay) with click fallback for desktop.
-     */
-    _fastTap(btn, handler) {
-        let touchFired = false;
-        // Use touchstart (not touchend) — on iOS/iPad, Leaflet's drag handler can
-        // cancel the touch sequence before touchend fires, swallowing the event.
-        // touchstart fires immediately when the finger goes down, before any drag
-        // logic can interfere. preventDefault() suppresses the subsequent click.
-        btn.addEventListener('touchstart', (e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            touchFired = true;
-            handler(e);
-        }, { passive: false });
-        btn.addEventListener('click', (e) => {
-            e.stopPropagation();
-            if (touchFired) { touchFired = false; return; } // already handled by touchstart
-            handler(e);
-        });
-        L.DomEvent.disableClickPropagation(btn);
-        L.DomEvent.disableScrollPropagation(btn);
-    }
-
     _addCornerButtons() {
         // 3 corner buttons in #mapCornerBtns (outside Leaflet, wired by app.js)
         // Expose references so app.js can wire them after init
@@ -1298,12 +1273,14 @@ class CockpitMap {
         autoPanBtn.title = 'Toggle auto-pan';
         autoPanBtn.innerHTML = this._autoPan ? '&#x1F4CD;' : '&#x270B;';
         autoPanBtn.classList.toggle('active', this._autoPan);
-        this._fastTap(autoPanBtn, () => {
+        wireTap(autoPanBtn, () => {
             this._autoPan = !this._autoPan;
             Settings.autoPan = this._autoPan;
             autoPanBtn.innerHTML = this._autoPan ? '&#x1F4CD;' : '&#x270B;';
             autoPanBtn.classList.toggle('active', this._autoPan);
         });
+        L.DomEvent.disableClickPropagation(autoPanBtn);
+        L.DomEvent.disableScrollPropagation(autoPanBtn);
         container.appendChild(autoPanBtn);
         this._autoPanBtn = autoPanBtn;
 
@@ -1312,11 +1289,13 @@ class CockpitMap {
         directToBtn.className = 'map-corner-btn direct-to-btn';
         directToBtn.title = 'Direct To';
         directToBtn.innerHTML = 'D&rarr;';
-        this._fastTap(directToBtn, () => {
+        wireTap(directToBtn, () => {
             if (typeof app !== 'undefined' && app.routeEditor) {
                 app.routeEditor.showDirectTo();
             }
         });
+        L.DomEvent.disableClickPropagation(directToBtn);
+        L.DomEvent.disableScrollPropagation(directToBtn);
         container.appendChild(directToBtn);
         this._directToBtn = directToBtn;
     }

--- a/web/cockpit/preflight-check.js
+++ b/web/cockpit/preflight-check.js
@@ -245,25 +245,13 @@ class PreflightCheck {
 
         document.body.appendChild(this._el);
 
-        this._wireTap(this._el.querySelector('.pfc-close'),      () => this.dismiss());
-        this._wireTap(this._el.querySelector('.pfc-btn-dismiss'), () => this.dismiss());
-        this._wireTap(this._el.querySelector('.pfc-btn-details'), () => {
+        wireTap(this._el.querySelector('.pfc-close'),      () => this.dismiss());
+        wireTap(this._el.querySelector('.pfc-btn-dismiss'), () => this.dismiss());
+        wireTap(this._el.querySelector('.pfc-btn-details'), () => {
             this.dismiss();
             // Open DataStatus if available
             if (window.app?.dataStatus) window.app.dataStatus.show();
         });
-    }
-
-    _wireTap(el, handler) {
-        if (!el) return;
-        let touchFired = false;
-        el.addEventListener('touchstart', (e) => {
-            e.stopPropagation();
-            touchFired = true;
-            handler(e);
-            setTimeout(() => { touchFired = false; }, 400);
-        });
-        el.addEventListener('click', (e) => { if (!touchFired) handler(e); });
     }
 
     static _css() {

--- a/web/cockpit/route-editor.js
+++ b/web/cockpit/route-editor.js
@@ -225,16 +225,16 @@ class RouteEditor {
         this._altInput = this._el.querySelector('.route-editor-alt');
         this._undoBtn = this._el.querySelector('.route-editor-undo');
 
-        // Events — use _wireTap for iPad touch reliability
-        this._wireTap(this._el.querySelector('.route-editor-close'), () => this.hide());
+        // Events
+        wireTap(this._el.querySelector('.route-editor-close'), () => this.hide());
         this._searchInput.addEventListener('input', () => this._onSearchInput());
         this._searchInput.addEventListener('keyup', () => this._onSearchInput());
         this._searchInput.addEventListener('paste', () => setTimeout(() => this._onSearchInput(), 50));
         // GO button: explicit trigger for Android paste (events unreliable)
-        this._wireTap(this._el.querySelector('.route-editor-go-btn'), () => this._onSearchInput());
-        this._wireTap(this._el.querySelector('.route-editor-nearby-btn'), () => this._showNearby());
-        this._wireTap(this._el.querySelector('.route-editor-maptap-btn'), () => this._toggleMapTapMode());
-        this._wireTap(this._undoBtn, () => this._popUndo());
+        wireTap(this._el.querySelector('.route-editor-go-btn'), () => this._onSearchInput());
+        wireTap(this._el.querySelector('.route-editor-nearby-btn'), () => this._showNearby());
+        wireTap(this._el.querySelector('.route-editor-maptap-btn'), () => this._toggleMapTapMode());
+        wireTap(this._undoBtn, () => this._popUndo());
         this._altInput.addEventListener('change', () => {
             this._altitude = parseInt(this._altInput.value) || 3500;
             // Push unlocked waypoints to the new cruise altitude immediately
@@ -245,19 +245,19 @@ class RouteEditor {
         });
 
         // Bottom bar: SAVE, LOAD, NEW, REV, UPLOAD — route management buttons
-        this._wireTap(this._el.querySelector('.re-new-btn'), () => {
+        wireTap(this._el.querySelector('.re-new-btn'), () => {
             if (typeof app !== 'undefined' && app.routeTable) app.routeTable._confirmNewRoute();
         });
-        this._wireTap(this._el.querySelector('.re-rev-btn'), () => {
+        wireTap(this._el.querySelector('.re-rev-btn'), () => {
             if (typeof app !== 'undefined' && app.routeTable) app.routeTable._reverseRoute();
         });
-        this._wireTap(this._el.querySelector('.re-load-btn'), () => {
+        wireTap(this._el.querySelector('.re-load-btn'), () => {
             if (typeof app !== 'undefined' && app.routeTable) app.routeTable._showPlanPicker();
         });
-        this._wireTap(this._el.querySelector('.re-upload-btn'), () => {
+        wireTap(this._el.querySelector('.re-upload-btn'), () => {
             if (typeof app !== 'undefined' && app.routeTable) app.routeTable._showUploadModal();
         });
-        this._wireTap(this._el.querySelector('.re-save-btn'), () => {
+        wireTap(this._el.querySelector('.re-save-btn'), () => {
             if (typeof app !== 'undefined' && app.routeTable) app.routeTable._saveRoute();
         });
     }
@@ -281,8 +281,8 @@ class RouteEditor {
         this._directToSearch = this._directToEl.querySelector('.direct-to-search');
         this._directToResults = this._directToEl.querySelector('.direct-to-results');
 
-        this._wireTap(this._directToEl.querySelector('.direct-to-close'), () => this.hideDirectTo());
-        this._wireTap(this._directToEl, (e) => {
+        wireTap(this._directToEl.querySelector('.direct-to-close'), () => this.hideDirectTo());
+        wireTap(this._directToEl, (e) => {
             if (e.target === this._directToEl) this.hideDirectTo();
         });
         this._directToSearch.addEventListener('input', () => this._onDirectToSearch());
@@ -389,7 +389,7 @@ class RouteEditor {
         }).join('');
 
         this._directToResults.querySelectorAll('.route-search-result').forEach(btn => {
-            this._wireTap(btn, () => {
+            wireTap(btn, () => {
                 this._executeDirectTo({
                     icao: btn.dataset.icao,
                     name: btn.dataset.name || btn.dataset.icao,
@@ -662,9 +662,9 @@ class RouteEditor {
 
         this._waypointsDiv.innerHTML = html;
 
-        // Attach events — use _wireTap for iPad touch reliability
+        // Attach events
         this._waypointsDiv.querySelectorAll('.route-wp-main').forEach(row => {
-            this._wireTap(row, (e) => {
+            wireTap(row, (e) => {
                 if (e.target?.classList?.contains('route-wp-remove')) return;
                 const idx = parseInt(row.parentElement.dataset.idx);
                 this._expandedIndex = (this._expandedIndex === idx) ? -1 : idx;
@@ -673,27 +673,27 @@ class RouteEditor {
         });
 
         this._waypointsDiv.querySelectorAll('.route-wp-remove').forEach(btn => {
-            this._wireTap(btn, () => {
+            wireTap(btn, () => {
                 this._removeWaypoint(parseInt(btn.dataset.idx));
             });
         });
 
         this._waypointsDiv.querySelectorAll('.route-wp-up').forEach(btn => {
-            this._wireTap(btn, () => {
+            wireTap(btn, () => {
                 const idx = parseInt(btn.dataset.idx);
                 this._moveWaypoint(idx, idx - 1);
             });
         });
 
         this._waypointsDiv.querySelectorAll('.route-wp-down').forEach(btn => {
-            this._wireTap(btn, () => {
+            wireTap(btn, () => {
                 const idx = parseInt(btn.dataset.idx);
                 this._moveWaypoint(idx, idx + 1);
             });
         });
 
         this._waypointsDiv.querySelectorAll('.route-wp-insert').forEach(btn => {
-            this._wireTap(btn, () => {
+            wireTap(btn, () => {
                 this._insertIndex = parseInt(btn.dataset.idx);
                 this._searchInput.focus();
                 this._searchInput.placeholder = `Insert at position ${this._insertIndex + 1}...`;
@@ -714,7 +714,7 @@ class RouteEditor {
         });
 
         this._waypointsDiv.querySelectorAll('.route-wp-alt-unlock').forEach(btn => {
-            this._wireTap(btn, () => {
+            wireTap(btn, () => {
                 const idx = parseInt(btn.dataset.idx);
                 this._waypoints[idx].altLocked = false;
                 this._waypoints[idx].alt = this._altitude;
@@ -897,7 +897,7 @@ class RouteEditor {
 
         const applyBtn = this._resultsDiv.querySelector('.route-parse-apply');
         if (applyBtn) {
-            this._wireTap(applyBtn, () => {
+            wireTap(applyBtn, () => {
                 this._pushUndo();
                 this._waypoints = resolved.map(wp => ({ ...wp, alt: this._altitude }));
                 this._insertIndex = -1;
@@ -966,7 +966,7 @@ class RouteEditor {
         `).join('');
 
         this._resultsDiv.querySelectorAll('.route-search-result').forEach(btn => {
-            this._wireTap(btn, () => {
+            wireTap(btn, () => {
                 const idx = this._insertIndex >= 0 ? this._insertIndex : this._waypoints.length;
                 this._addWaypoint({
                     icao: btn.dataset.id,
@@ -1009,37 +1009,6 @@ class RouteEditor {
             this._resultsDiv.hidden = false;
             this._resultsDiv.innerHTML = '<div class="route-search-empty">Airport database not available</div>';
         }
-    }
-
-    /** Wire touchstart + click with debounce for iPad reliability */
-    _wireTap(el, handler) {
-        if (!el) return;
-        let startX = 0, startY = 0, isTap = false, touchUsed = false;
-        el.addEventListener('touchstart', (e) => {
-            const t = e.touches[0];
-            startX = t.clientX;
-            startY = t.clientY;
-            isTap = true;
-        }, { passive: true });
-        el.addEventListener('touchmove', (e) => {
-            if (!isTap) return;
-            const t = e.touches[0];
-            if (Math.abs(t.clientX - startX) > 10 || Math.abs(t.clientY - startY) > 10) {
-                isTap = false;
-            }
-        }, { passive: true });
-        el.addEventListener('touchend', (e) => {
-            if (isTap) {
-                e.stopPropagation();
-                touchUsed = true;
-                handler(e);
-                setTimeout(() => { touchUsed = false; }, 400);
-            }
-            isTap = false;
-        });
-        el.addEventListener('click', (e) => {
-            if (!touchUsed) handler(e);
-        });
     }
 
     // ========== Apply / Persist ==========

--- a/web/cockpit/route-table.js
+++ b/web/cockpit/route-table.js
@@ -2104,12 +2104,31 @@ class RouteTable {
                 }
             }
         });
-        // Touchend delegation for iPad reliability on power/rules headers
+        // Touchend delegation for Android reliability — covers all row interactions.
+        // e.preventDefault() suppresses the synthetic click so the click handler below
+        // doesn't double-fire on touch devices.
         this._tableEl.addEventListener('touchend', (e) => {
+            const del = e.target.closest('.rt-delete-btn');
+            if (del) { e.preventDefault(); e.stopPropagation(); this._removeWaypoint(parseInt(del.dataset.idx)); return; }
+            const up = e.target.closest('.rt-up-btn');
+            if (up) { e.preventDefault(); e.stopPropagation(); this._moveWaypoint(parseInt(up.dataset.idx), parseInt(up.dataset.idx) - 1); return; }
+            const down = e.target.closest('.rt-down-btn');
+            if (down) { e.preventDefault(); e.stopPropagation(); this._moveWaypoint(parseInt(down.dataset.idx), parseInt(down.dataset.idx) + 1); return; }
+            const altCell = e.target.closest('.rt-alt-cell');
+            if (altCell && this._editMode) { e.preventDefault(); e.stopPropagation(); this._showAltPicker(parseInt(altCell.dataset.idx), altCell); return; }
             const pwr = e.target.closest('.rt-pwr-header');
-            if (pwr) { e.preventDefault(); e.stopPropagation(); this._cycleCruisePower(); }
+            if (pwr) { e.preventDefault(); e.stopPropagation(); this._cycleCruisePower(); return; }
             const rules = e.target.closest('.rt-rules-header');
-            if (rules) { e.preventDefault(); e.stopPropagation(); this._toggleFlightRules(); }
+            if (rules) { e.preventDefault(); e.stopPropagation(); this._toggleFlightRules(); return; }
+            const row = e.target.closest('.rt-row');
+            if (row) {
+                const idx = parseInt(row.dataset.idx);
+                const wp = this._waypoints[idx];
+                if (wp?.lat && wp.lon && this._map) {
+                    e.preventDefault();
+                    this._map.panTo([wp.lat, wp.lon]);
+                }
+            }
         });
 
         // Altitude picker overlay (reused, hidden by default)

--- a/web/cockpit/route-table.js
+++ b/web/cockpit/route-table.js
@@ -2384,11 +2384,12 @@ class RouteTable {
      * Uses movement guard to distinguish tap from scroll; matches airport-popup pattern.
      */
     _wireButton(btn, action) {
-        let startX = 0, startY = 0, isTap = false;
+        let startX = 0, startY = 0, isTap = false, touchHandled = false;
         btn.addEventListener('touchstart', (e) => {
             startX = e.touches[0].clientX;
             startY = e.touches[0].clientY;
             isTap = true;
+            touchHandled = false;
         }, { passive: true });
         btn.addEventListener('touchmove', (e) => {
             if (!isTap) return;
@@ -2396,10 +2397,13 @@ class RouteTable {
                 Math.abs(e.touches[0].clientY - startY) > 10) isTap = false;
         }, { passive: true });
         btn.addEventListener('touchend', (e) => {
-            if (isTap) { e.stopPropagation(); action(); }
+            if (isTap) { e.stopPropagation(); touchHandled = true; action(); }
             isTap = false;
+        }, { passive: true });
+        btn.addEventListener('click', (e) => {
+            if (touchHandled) { touchHandled = false; return; }
+            e.stopPropagation(); action();
         });
-        btn.addEventListener('click', (e) => { e.stopPropagation(); action(); });
     }
 
     // Drag removed in v5 — route display uses tap-to-toggle only

--- a/web/cockpit/route-table.js
+++ b/web/cockpit/route-table.js
@@ -1852,7 +1852,7 @@ class RouteTable {
                 <div class="plan-picker-footer"></div>
             </div>`;
 
-        this._wireButton(overlay.querySelector('.plan-picker-close'), () => overlay.remove());
+        wireTap(overlay.querySelector('.plan-picker-close'), () => overlay.remove());
         // Dismiss on tap outside modal — guard against synthetic click from opening tap
         const openedAt = Date.now();
         const dismissOverlay = (e) => {
@@ -1864,7 +1864,7 @@ class RouteTable {
 
         // Plan items — load from localStorage by index
         overlay.querySelectorAll('.plan-picker-item').forEach(btn => {
-            this._wireButton(btn, async () => {
+            wireTap(btn, async () => {
                 try {
                     const idx = parseInt(btn.dataset.idx);
                     const plan = plans[idx];
@@ -2050,7 +2050,7 @@ class RouteTable {
 
         // EDIT button opens the separate route editor
         this._editBtn = this._handleEl.querySelector('.route-table-edit-btn');
-        this._wireButton(this._editBtn, () => {
+        wireTap(this._editBtn, () => {
             console.log('[RouteTable] EDIT button fired, routeEditor=', !!(typeof app !== 'undefined' && app.routeEditor));
             if (typeof app !== 'undefined' && app.routeEditor) {
                 app.routeEditor.startEditRoute();
@@ -2058,10 +2058,10 @@ class RouteTable {
         });
 
         this._profileBtn = this._handleEl.querySelector('.rt-profile-btn');
-        this._wireButton(this._profileBtn, () => this._openProfileView());
+        wireTap(this._profileBtn, () => this._openProfileView());
 
         this._toggleBtn = this._handleEl.querySelector('.rt-toggle-btn');
-        this._wireButton(this._toggleBtn, () => this.toggle());
+        wireTap(this._toggleBtn, () => this.toggle());
 
         // Terrain profile panel (created once, floats above the sheet)
         this._profileView = (typeof RouteProfileView !== 'undefined')
@@ -2377,33 +2377,6 @@ class RouteTable {
             return window.terrainGrid.buildProfile(coords, 1.0);
         }
         return [];
-    }
-
-    /**
-     * Wire a button with touchend + click fallback.
-     * Uses movement guard to distinguish tap from scroll; matches airport-popup pattern.
-     */
-    _wireButton(btn, action) {
-        let startX = 0, startY = 0, isTap = false, touchHandled = false;
-        btn.addEventListener('touchstart', (e) => {
-            startX = e.touches[0].clientX;
-            startY = e.touches[0].clientY;
-            isTap = true;
-            touchHandled = false;
-        }, { passive: true });
-        btn.addEventListener('touchmove', (e) => {
-            if (!isTap) return;
-            if (Math.abs(e.touches[0].clientX - startX) > 10 ||
-                Math.abs(e.touches[0].clientY - startY) > 10) isTap = false;
-        }, { passive: true });
-        btn.addEventListener('touchend', (e) => {
-            if (isTap) { e.stopPropagation(); touchHandled = true; action(); }
-            isTap = false;
-        }, { passive: true });
-        btn.addEventListener('click', (e) => {
-            if (touchHandled) { touchHandled = false; return; }
-            e.stopPropagation(); action();
-        });
     }
 
     // Drag removed in v5 — route display uses tap-to-toggle only

--- a/web/cockpit/tab-bar.js
+++ b/web/cockpit/tab-bar.js
@@ -67,6 +67,7 @@ class TabBar {
         if (c.approachCharts?.closeViewer) c.approachCharts.closeViewer();
         if (c.fuelOverlay?.hide) c.fuelOverlay.hide();
         if (c.planSync?.hide) c.planSync.hide();
+        if (c.fisbStatus?.hide) c.fisbStatus.hide();
         if (c.airportPopup?.close) c.airportPopup.close();
 
         // Hide radar loop controls when leaving map — they bleed through

--- a/web/cockpit/tab-bar.js
+++ b/web/cockpit/tab-bar.js
@@ -37,7 +37,7 @@ class TabBar {
             btn.className = 'tab-btn' + (tab.id === 'map' ? ' active' : '');
             btn.dataset.tab = tab.id;
             btn.innerHTML = `<span class="tab-btn-icon">${tab.icon}</span>${tab.label}`;
-            this._fastTap(btn, () => this._selectTab(tab.id, btn));
+            wireTap(btn, () => this._selectTab(tab.id, btn));
             tabBar.appendChild(btn);
         }
     }
@@ -231,7 +231,7 @@ class TabBar {
 
         const closeBtn = this._moreDrawer.querySelector('.more-drawer-close');
         if (closeBtn) {
-            this._fastTap(closeBtn, () => this._closeMoreDrawer());
+            wireTap(closeBtn, () => this._closeMoreDrawer());
         }
 
         const body = this._moreDrawer.querySelector('.more-drawer-body');
@@ -241,7 +241,7 @@ class TabBar {
             const labelText = typeof row.label === 'function' ? row.label() : row.label;
             el.innerHTML = `<span class="md-icon">${row.icon}</span><span class="md-label">${labelText}</span><span class="md-chevron">›</span>`;
             // Use scroll-safe tap: don't preventDefault on touchstart so scroll still works
-            this._scrollSafeTap(el, row.action);
+            wireTap(el, row.action);
             body.appendChild(el);
         }
 
@@ -326,7 +326,7 @@ class TabBar {
             <div class="ml-mon-body" id="mlMonBody"></div>`;
 
         document.body.appendChild(overlay);
-        this._fastTap(overlay.querySelector('#mlMonClose'), () => overlay.remove());
+        wireTap(overlay.querySelector('#mlMonClose'), () => overlay.remove());
 
         this._mlMonitorEl = overlay.querySelector('#mlMonBody');
         this._renderMLMonitor();
@@ -360,7 +360,7 @@ class TabBar {
                 <h3 class="ml-mon-section-title">Maintenance</h3>
                 <button class="ml-mon-reset-btn" id="mlResetThresholds">Reset Adapted Thresholds</button>
             </div>`;
-            this._fastTap(body.querySelector('#mlResetThresholds'), async () => {
+            wireTap(body.querySelector('#mlResetThresholds'), async () => {
                 if (!confirm('Reset all adapted thresholds? The model will revert to trained defaults and re-learn from scratch. Do this after engine maintenance or a phase detection bug fix.')) return;
                 await window.app?.engineML?.resetThresholds();
                 const btn = body.querySelector('#mlResetThresholds');
@@ -432,7 +432,7 @@ class TabBar {
 
         body.innerHTML = html;
 
-        this._fastTap(body.querySelector('#mlResetThresholds'), async () => {
+        wireTap(body.querySelector('#mlResetThresholds'), async () => {
             if (!confirm('Reset all adapted thresholds? The model will revert to trained defaults and re-learn from scratch. Do this after engine maintenance or a phase detection bug fix.')) return;
             await window.app?.engineML?.resetThresholds();
             const btn = body.querySelector('#mlResetThresholds');
@@ -475,7 +475,7 @@ class TabBar {
         const resetBtn = el.querySelector('.ft-reset');
         const closeBtn = el.querySelector('.ft-close');
 
-        this._fastTap(startBtn, () => {
+        wireTap(startBtn, () => {
             if (this._timerRunning) {
                 this._timerElapsed += Date.now() - this._timerStartMs;
                 this._timerRunning = false;
@@ -491,7 +491,7 @@ class TabBar {
             }
         });
 
-        this._fastTap(resetBtn, () => {
+        wireTap(resetBtn, () => {
             this._timerRunning = false;
             this._timerElapsed = 0;
             this._timerStartMs = 0;
@@ -501,7 +501,7 @@ class TabBar {
             startBtn.classList.remove('ft-running');
         });
 
-        this._fastTap(closeBtn, () => {
+        wireTap(closeBtn, () => {
             el.classList.add('hidden');
         });
 
@@ -550,43 +550,6 @@ class TabBar {
             const up = () => { document.removeEventListener('mousemove', move); };
             document.addEventListener('mousemove', move);
             document.addEventListener('mouseup', up, { once: true });
-        });
-    }
-
-    /**
-     * Scroll-safe tap handler for list items inside scrollable containers.
-     * Does NOT preventDefault on touchstart, so the parent can still scroll.
-     * Detects tap vs scroll by tracking movement — if finger moves >8px it's a scroll, not a tap.
-     */
-    _scrollSafeTap(el, handler) {
-        let startY = null;
-        el.addEventListener('touchstart', (e) => {
-            startY = e.touches[0].clientY;
-        }, { passive: true });
-        el.addEventListener('touchend', (e) => {
-            if (startY === null) return;
-            const dy = Math.abs(e.changedTouches[0].clientY - startY);
-            startY = null;
-            if (dy < 8) handler(e);
-        }, { passive: true });
-        el.addEventListener('click', (e) => {
-            handler(e);
-        });
-    }
-
-    /** Reliable tap handler for both touch and mouse */
-    _fastTap(btn, handler) {
-        let touchFired = false;
-        btn.addEventListener('touchstart', (e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            touchFired = true;
-            handler(e);
-        }, { passive: false });
-        btn.addEventListener('click', (e) => {
-            e.stopPropagation();
-            if (touchFired) { touchFired = false; return; }
-            handler(e);
         });
     }
 

--- a/web/index.html
+++ b/web/index.html
@@ -78,6 +78,7 @@
     <script src="./shared/fuel-state.js"></script>
     <script src="./shared/fuel-tank-state.js"></script>
     <script src="./shared/sync-shim.js"></script>
+    <script src="./shared/tap-utils.js"></script>
     <script src="./shared/network-mode.js"></script>
 
     <!-- Config (must load before cockpit modules) -->

--- a/web/shared/tap-utils.js
+++ b/web/shared/tap-utils.js
@@ -1,0 +1,34 @@
+/**
+ * wireTap(el, handler)
+ * Canonical tap handler for all FlyTab UI buttons.
+ * - touchstart (passive): records finger position and timestamp
+ * - touchend (passive): fires handler if < 20px movement and < 500ms
+ * - click: fallback for desktop/mouse (suppressed after touch)
+ *
+ * Do NOT use for Leaflet SVG polygon hit-testing — that uses a separate
+ * touchstart/touchend pair on the map container with capture:true.
+ */
+function wireTap(el, handler) {
+    if (!el) return;
+    let tapStart = null, touchHandled = false;
+    el.addEventListener('touchstart', (e) => {
+        if (e.touches.length === 1)
+            tapStart = { x: e.touches[0].clientX, y: e.touches[0].clientY, t: Date.now() };
+        else tapStart = null;
+        touchHandled = false;
+    }, { passive: true });
+    el.addEventListener('touchend', (e) => {
+        if (!tapStart || e.changedTouches.length !== 1) { tapStart = null; return; }
+        const ts = tapStart; tapStart = null;
+        const dx = e.changedTouches[0].clientX - ts.x;
+        const dy = e.changedTouches[0].clientY - ts.y;
+        if (dx * dx + dy * dy > 400) return;
+        if (Date.now() - ts.t > 500) return;
+        touchHandled = true;
+        handler(e);
+    }, { passive: true });
+    el.addEventListener('click', (e) => {
+        if (touchHandled) { touchHandled = false; return; }
+        handler(e);
+    });
+}

--- a/web/style.css
+++ b/web/style.css
@@ -6297,17 +6297,17 @@ body {
     line-height: 1;
 }
 
-/* Layer panel: slide-in from right */
+/* Layer panel: slide-in from left */
 .layer-panel {
     position: fixed;
     top: 0;
-    right: 0;
+    left: 0;
     bottom: 0;
     width: 280px;
     z-index: 1010;
     background: var(--bg-surface);
-    border-left: 1px solid var(--border-strong);
-    transform: translateX(100%);
+    border-right: 1px solid var(--border-strong);
+    transform: translateX(-100%);
     transition: transform 0.2s ease;
     display: flex;
     flex-direction: column;

--- a/web/style.css
+++ b/web/style.css
@@ -6297,17 +6297,17 @@ body {
     line-height: 1;
 }
 
-/* Layer panel: slide-in from left */
+/* Layer panel: slide-in from right */
 .layer-panel {
     position: fixed;
     top: 0;
-    left: 0;
+    right: 0;
     bottom: 0;
     width: 280px;
     z-index: 1010;
     background: var(--bg-surface);
-    border-right: 1px solid var(--border-strong);
-    transform: translateX(-100%);
+    border-left: 1px solid var(--border-strong);
+    transform: translateX(100%);
     transition: transform 0.2s ease;
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary

- **#3** — Add `Tailscale → OFF` to VFR Before Start checklist, after ExpressVPN
- **#33** — Layer panel now slides in from the right edge (`right: 0`, `translateX(100%)`, `border-left`)
- **#71** — Unified 4 divergent touch-handler implementations into a single shared `wireTap()` in `web/shared/tap-utils.js`; ~300 lines of duplicated boilerplate removed across 15 cockpit files
- **#74** — Added post-apply sanity check in `_applyPlan()` that logs `routeTable` vs `routeEditor` waypoint-count divergence to DiagLog when they differ under rapid edits

## Touch handler unification detail (#71)

All per-class `_fastTap`, `_scrollSafeTap`, `_wireTap`, and `_wireButton` methods replaced by a single canonical `wireTap(el, handler)` (touchend-based, passive, 20 px radius, 500 ms guard — the pattern established in PR #83). Zero legacy implementations remain in `web/cockpit/`.

## Test plan

- [ ] VFR checklist → Before Start: "Tailscale — OFF" appears after "ExpressVPN — OFF"
- [ ] Tap Layers (≡) button → panel slides in from the **right** edge; close slides it back right
- [ ] Everywhere search: tap result row, back arrow, close (✕) — no double-fire
- [ ] Route editor: tap NEW, REV, waypoint add/remove — all register correctly
- [ ] Route table: tap EDIT, ▲/▼ toggle — correct response
- [ ] Airport popup: tap frequency row, close — no phantom taps
- [ ] Tab bar: tap tabs and more-drawer rows — correct tab activates
- [ ] Layer panel toggles: tap each layer on/off — responds on first tap
- [ ] `grep -rn "_fastTap\|_scrollSafeTap\|_wireTap\|_wireButton" web/cockpit/` → zero results
- [ ] Long-press version badge → DiagLog opens; no spurious `state-drift` entries during normal editing

🤖 Generated with [Claude Code](https://claude.com/claude-code)