### PR TITLE
fix: reliable route editing — block map inserts, fix double-delete (v5.97)

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "app.flywhere.flytab"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 596
-        versionName "5.96"
+        versionCode 597
+        versionName "5.97"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/docs/superpowers/specs/2026-04-25-wx-briefing-redesign-design.md
+++ b/docs/superpowers/specs/2026-04-25-wx-briefing-redesign-design.md
@@ -1,0 +1,213 @@
+# WxBriefing Redesign — Design Spec
+**Date:** 2026-04-25  
+**Status:** Approved for implementation planning
+
+---
+
+## Overview
+
+Redesign `web/cockpit/wx-briefing.js` into a full preflight weather briefing panel that consolidates all internet-sourced weather data into one place. Used in landscape mode during preflight planning (internet connected). The existing portrait MOS grid is preserved; new data sources are added alongside it.
+
+---
+
+## Layout
+
+### Landscape (planning mode — primary use)
+
+Two-column layout inside a fixed-height panel:
+
+**Left column (52%) — station data, scrollable:**
+1. Summary bar (route + best-day badge) — sticky
+2. MOS grid (7-day or 24H toggle)
+3. Hourly drill-down (appears below grid when a cell is tapped)
+4. "METARs & TAFs" section header — sticky
+5. METAR/TAF cards, one per station, sorted by proximity to route
+
+**Right column (48%) — area/corridor data, scrollable:**
+1. AIRMETs
+2. Mesoscale Discussions (MCDs)
+3. Forecast Discussions (AFDs)
+4. NOTAMs
+
+**Header (full width, fixed):** route label · age indicators · 7-DAY/24H toggle · ↻ refresh
+
+### Portrait (informational — not the primary planning use case)
+
+Existing single-column layout is preserved. New sections (METARs/TAFs, AIRMETs, MCDs, AFDs, NOTAMs) are appended as collapsible sections below the MOS grid, same pattern as existing WxBriefing.
+
+---
+
+## MOS Grid (existing, enhanced)
+
+### 7-DAY mode
+- One column per day, worst flight category during prime flying hours (15Z–03Z)
+- Tap any cell → hourly timeline replaces empty space below grid in left column
+- Hourly timeline shows: time (local), flight category (color-coded), ceiling, visibility, wind, weather phenomena
+- Marginal periods highlighted with amber outline row background
+- Summary note at bottom: derived from hourly data — find contiguous marginal/IFR periods and describe them in plain language, e.g. "MVFR 6–11 AM only. Afternoon VFR."
+
+### 24H mode
+- One column per 3-hour MOS period, next 24 hours
+- Each cell shows: category, ceiling/sky, vis, wind, ⛈% if ≥20%
+- Marginal periods highlighted with amber outline
+- Horizontally scrollable
+
+---
+
+## METARs & TAFs
+
+### Data source
+- METARs: `https://aviationweather.gov/api/data/metar?bbox={s},{w},{n},{e}&format=json` where the bbox is the route corridor bounding box expanded by ~0.15° (~10 nm) on each side. Returns all reporting stations in the corridor in one request.
+- TAFs: `https://aviationweather.gov/api/data/taf?ids=...&format=json` for route airports only (TAFs exist only at towered/controlled fields — not worth fetching by bbox). AWC JSON response includes structured `fcsts` array with per-period conditions — no raw text parsing needed.
+- Route airports are fetched by `ids=` for the TAF call; nearby stations come from the bbox METAR call.
+
+### Station sorting
+1. Route airports (departure, destination, intermediate waypoints) — labeled "ON ROUTE"
+2. Airports within 10 nm of any route segment, sorted ascending by distance from nearest route segment
+
+### Display (per station card, collapsible)
+**Card header (always visible):**
+- Airport ID · proximity badge (ON ROUTE / X.X nm) · observation time (local) · flight category badge
+
+**Expanded:**
+- Raw METAR string (monospace)
+- Decoded fields grid: Wind, Visibility, Ceiling, Temp/Dew, Altimeter, Observed (local time)
+- TAF section (if available):
+  - "Issued HH:MM L · Valid [day time] → [day time] L"
+  - One row per forecast group from AWC `fcsts` array: local time range · flight category badge (computed from ceiling/vis) · wind · ceiling · visibility
+
+### Time decoding
+All UTC timestamps decoded to device local time using `Date` object local methods. Format: `2:53 PM L` for observations, `Sat 3PM → Sun 6AM L` for TAF validity periods.
+
+### Fetch trigger
+- On `show()` if cache is cold (>15 min old or absent)
+- On ↻ refresh (parallel with all other fetches)
+- Cached in `localStorage` under `flytab_metar_cache` with 15-min TTL
+
+---
+
+## AIRMETs
+
+### Data source
+`WeatherClient.fetchAndCacheAdvisories()` — already implemented, fetches from `flywhere.app/api/weather?type=airsigmet`. AIRMETs are already parsed and cached in `flytab_advisories_cache`.
+
+### Filtering
+Route corridor: 50 nm buffer around all route segments. Filter to AIRMETs whose polygon intersects the corridor using the same point-in-polygon logic as MCDs.
+
+### Display (per AIRMET card, collapsible)
+**Header:** type (SIERRA / TANGO / ZULU) · hazard · valid until (local time)  
+**Expanded:** full advisory text (monospace, max 180px scrollable)
+
+---
+
+## Mesoscale Discussions (MCDs)
+
+### Data source
+`https://api.weather.gov/products?type=MCD&office=KWNS&limit=20`  
+Returns JSON array with `id`, `issuanceTime`, `productText` fields. CORS-permissive — no proxy needed.
+
+### Polygon parsing
+Each MCD `productText` contains a `LAT...LON` line with space-separated coordinate tokens. Parse all numeric tokens after `LAT...LON`:
+- Tokens ≤ 5999 are latitudes: divide by 100 → decimal degrees N
+- Tokens ≥ 6000 are longitudes: divide by 100 → decimal degrees W (negate)
+- Pairs alternate lat/lon
+
+### Route filtering
+1. Build bounding box around route with 50 nm buffer
+2. Pre-filter: discard MCDs whose polygon bounding box does not intersect route bounding box
+3. For remaining: ray-casting point-in-polygon check — any route waypoint inside MCD polygon = match
+
+### Display (per MCD card, collapsible)
+**Header:** MD NNNN · hazard summary · valid until (local time)  
+**Expanded:** full `productText` (monospace, max 200px scrollable), with issued/valid times decoded to local
+
+### Caching
+`localStorage` key `flytab_mcd_cache`, 15-min TTL. Fetch on `show()` if cold; refresh on ↻.
+
+---
+
+## Area Forecast Discussions (AFDs)
+
+### Data source
+`https://api.weather.gov/products?type=AFD&office=XXXX` — one request per NWS office covering the route.
+
+### Office selection
+Call `https://api.weather.gov/points/{lat},{lon}` for the departure and destination coordinates. Response includes `cwa` (office ID) and `forecastOffice` URL. Deduplicate office IDs — typically 1–3 offices per route. One `products?type=AFD&office=XXXX` call per unique office.
+
+### Display (per AFD card, collapsible)
+**Header:** office ID (e.g. KGSP) · office name · issued time (local)  
+**Expanded:** full AFD text (monospace, max 200px scrollable)
+
+### Caching
+`localStorage` key `flytab_afd_cache`, 60-min TTL (AFDs update every 6–12 hours).
+
+---
+
+## NOTAMs
+
+### Data source
+FAA NMS-API v1 (CGI Federal):
+- **Test:** `https://api-staging.cgifederal-aim.com/nmsapi/v1`
+- **Production:** TBD (provided after test environment validation)
+- Authentication: API key stored in `cockpit-config.json` under `notam_api_key`
+
+### Query
+Fetch NOTAMs for each route airport by ICAO identifier plus a 10 nm radius. Deduplicate by NOTAM number.
+
+### Parsing & display (per NOTAM card, collapsible)
+**Card (collapsed):**
+- Airport · type badge (RWY / NAVAID / OBST / TWY / AD / SVC) — RWY/NAVAID shown in red as critical
+- Summary line (decoded from NOTAM text: what is affected)
+- Valid period (local time): `Mon Apr 27 6:00 AM L → Tue Apr 28 6:00 AM L`
+
+**Expanded:** raw NOTAM string (monospace)
+
+### Sorting
+1. Critical types (RWY, NAVAID) first
+2. Then by airport (route order)
+3. Then by valid-from time ascending
+
+### Caching
+`localStorage` key `flytab_notam_cache`, 15-min TTL.
+
+---
+
+## Refresh Behavior
+
+The ↻ button triggers all fetches in parallel:
+```
+Promise.allSettled([fetchMos(), fetchMetars(), fetchAirmets(), fetchMcds(), fetchAfds(), fetchNotams()])
+```
+Each section renders independently as its data resolves — no section blocks another. A per-section loading spinner is shown while its fetch is in flight.
+
+Auto-fetch on `show()`: each data type checks its own cache TTL independently. Cold caches trigger a fetch; warm caches render immediately.
+
+---
+
+## Error Handling
+
+Each section has an independent error state: "Fetch failed — tap ↻ to retry." Non-blocking — other sections continue to render normally.
+
+No internet → all sections show cached data with age indicator, or "No data cached — requires internet."
+
+---
+
+## Configuration
+
+New fields in `cockpit-config.json`:
+```json
+{
+  "notam_api_key": "",
+  "notam_api_base": "https://api-staging.cgifederal-aim.com/nmsapi/v1"
+}
+```
+
+`notam_api_base` defaults to the test environment URL until production onboarding is complete.
+
+---
+
+## Implementation Scope
+
+All changes are confined to `web/cockpit/wx-briefing.js` and `web/style.css`. No new files are created. `WeatherClient` is used for METARs/TAFs/AIRMETs (already implemented). MCD and AFD fetches are new methods added to `WxBriefing` directly (lightweight enough to not warrant a shared client). NOTAM fetching is a new method in `WxBriefing`.
+
+The existing `PreflightBrief` (`preflight-brief.js`) is not modified — consolidation of its weather data into `WxBriefing` is a separate future effort.

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,7 @@
  * Android Capacitor cockpit app. All data local. Pi for live telemetry only.
  */
 
-const FLYTAB_VERSION = 'v5.96';
+const FLYTAB_VERSION = 'v5.97';
 
 // ========== Diagnostic Logger (ring buffer in localStorage) ==========
 const DiagLog = (() => {
@@ -409,6 +409,7 @@ class FlyTabApp {
                 this.airportPopup.setVectorLayers(this.vectorLayers);
                 this.vectorLayers._onInternetMetarsFetched = () => this._updateWeatherAge(this._currentTrip);
                 this.vectorLayers.onAirportClick((apt) => {
+                    if (this.routeEditor?.isVisible()) return;
                     if (this.routeTable?.isEditing()) {
                         this.routeTable.addWaypointSmart({
                             icao: apt.icao, name: apt.name || apt.icao,
@@ -420,6 +421,7 @@ class FlyTabApp {
                 });
 
                 this.vectorLayers.onNavaidClick((nav) => {
+                    if (this.routeEditor?.isVisible()) return;
                     if (this.routeTable?.isEditing()) {
                         this.routeTable.addWaypointSmart({
                             icao: nav.id, name: nav.name || nav.id,
@@ -431,6 +433,7 @@ class FlyTabApp {
                 });
 
                 this.vectorLayers.onFixClick((fix) => {
+                    if (this.routeEditor?.isVisible()) return;
                     if (this.routeTable?.isEditing()) {
                         this.routeTable.addWaypointSmart({
                             icao: fix.id, name: fix.id,

--- a/web/cockpit/route-editor.js
+++ b/web/cockpit/route-editor.js
@@ -20,8 +20,6 @@ class RouteEditor {
         this._insertIndex = -1; // -1 = append
         this._expandedIndex = -1;
         this._searchDebounce = null;
-        this._mapTapMode = false;
-        this._mapTapHandler = null;
         this._plan = null; // reference to loaded plan for metadata
         this._parseSeq = 0; // sequence counter to discard stale route parse results
     }
@@ -33,7 +31,6 @@ class RouteEditor {
 
     destroy() {
         this.hide();
-        this._disableMapTapMode();
         if (this._el && this._el.parentNode) this._el.remove();
         if (this._directToEl && this._directToEl.parentNode) this._directToEl.remove();
     }
@@ -48,7 +45,6 @@ class RouteEditor {
     hide() {
         this._visible = false;
         this._el.classList.remove('route-editor-visible');
-        this._disableMapTapMode();
         this._clearSearch();
     }
 
@@ -194,7 +190,6 @@ class RouteEditor {
                 <input type="text" class="input route-editor-search" placeholder="Search or paste route..." autocomplete="off" autocorrect="off" spellcheck="false">
                 <button class="btn btn-primary route-editor-go-btn" title="Parse route or search">GO</button>
                 <button class="btn btn-secondary route-editor-nearby-btn" title="Nearby airports">NEARBY</button>
-                <button class="btn btn-secondary route-editor-maptap-btn" title="Tap map to add">MAP+</button>
             </div>
             <div class="route-editor-results" hidden></div>
             <div class="route-editor-controls">
@@ -233,7 +228,6 @@ class RouteEditor {
         // GO button: explicit trigger for Android paste (events unreliable)
         wireTap(this._el.querySelector('.route-editor-go-btn'), () => this._onSearchInput());
         wireTap(this._el.querySelector('.route-editor-nearby-btn'), () => this._showNearby());
-        wireTap(this._el.querySelector('.route-editor-maptap-btn'), () => this._toggleMapTapMode());
         wireTap(this._undoBtn, () => this._popUndo());
         this._altInput.addEventListener('change', () => {
             this._altitude = parseInt(this._altInput.value) || 3500;
@@ -492,79 +486,6 @@ class RouteEditor {
         const projLat = aLat + t * dy;
         const projLon = aLon + t * dx;
         return CockpitMap._distNm(pLat, pLon, projLat, projLon);
-    }
-
-    // ========== Map Tap Mode ==========
-
-    _toggleMapTapMode() {
-        if (this._mapTapMode) {
-            this._disableMapTapMode();
-        } else {
-            this._enableMapTapMode();
-        }
-    }
-
-    _enableMapTapMode() {
-        if (!this.cockpitMap || !this.cockpitMap.map) return;
-        this._mapTapMode = true;
-        const btn = this._el.querySelector('.route-editor-maptap-btn');
-        if (btn) btn.classList.add('active');
-        this.cockpitMap.map.getContainer().style.cursor = 'crosshair';
-
-        this._mapTapHandler = async (e) => {
-            const { lat, lng } = e.latlng;
-            // Find nearest airport within 5nm
-            try {
-                const nearby = await this.nasrDb.getAirportsNear(lat, lng, 5);
-                if (nearby.length > 0) {
-                    nearby.sort((a, b) =>
-                        CockpitMap._distNm(lat, lng, a.lat, a.lon) -
-                        CockpitMap._distNm(lat, lng, b.lat, b.lon)
-                    );
-                    const apt = nearby[0];
-                    const idx = this._insertIndex >= 0 ? this._insertIndex : this._waypoints.length;
-                    this._addWaypoint({
-                        icao: apt.icao, name: apt.name || apt.icao,
-                        lat: apt.lat, lon: apt.lon, alt: this._altitude,
-                        type: 'APT',
-                    }, idx);
-                } else {
-                    // Add as lat/lon waypoint
-                    const idx = this._insertIndex >= 0 ? this._insertIndex : this._waypoints.length;
-                    this._addWaypoint({
-                        icao: `${lat.toFixed(2)}/${lng.toFixed(2)}`,
-                        name: `${lat.toFixed(2)}/${lng.toFixed(2)}`,
-                        lat, lon: lng, alt: this._altitude,
-                        type: 'GPS',
-                    }, idx);
-                }
-            } catch {
-                // Fallback: add as lat/lon
-                const idx = this._insertIndex >= 0 ? this._insertIndex : this._waypoints.length;
-                this._addWaypoint({
-                    icao: `${lat.toFixed(2)}/${lng.toFixed(2)}`,
-                    name: `${lat.toFixed(2)}/${lng.toFixed(2)}`,
-                    lat, lon: lng, alt: this._altitude,
-                    type: 'GPS',
-                }, idx);
-            }
-            this._disableMapTapMode();
-        };
-
-        this.cockpitMap.map.once('click', this._mapTapHandler);
-    }
-
-    _disableMapTapMode() {
-        this._mapTapMode = false;
-        const btn = this._el?.querySelector('.route-editor-maptap-btn');
-        if (btn) btn.classList.remove('active');
-        if (this.cockpitMap?.map) {
-            this.cockpitMap.map.getContainer().style.cursor = '';
-            if (this._mapTapHandler) {
-                this.cockpitMap.map.off('click', this._mapTapHandler);
-                this._mapTapHandler = null;
-            }
-        }
     }
 
     // ========== Render Waypoints ==========

--- a/web/cockpit/route-table.js
+++ b/web/cockpit/route-table.js
@@ -2105,7 +2105,10 @@ class RouteTable {
 
         // Delegated event listeners for all interactive table elements.
         // Delegation survives DOM rebuilds from live Stratux updates (issue #30).
+        // Belt-and-suspenders: also check _wireTapLastTouchAt (from tap-utils.js) to
+        // suppress synthetic clicks that slip through e.preventDefault() on some Android versions.
         this._tableEl.addEventListener('click', (e) => {
+            if (Date.now() - (_wireTapLastTouchAt || 0) < 350) return;
             const del = e.target.closest('.rt-delete-btn');
             if (del) { e.stopPropagation(); this._removeWaypoint(parseInt(del.dataset.idx)); return; }
             const demote = e.target.closest('.rt-demote-fuel-stop-btn');
@@ -2134,23 +2137,23 @@ class RouteTable {
             }
         });
         // Touchend delegation for Android reliability — covers all row interactions.
-        // e.preventDefault() suppresses the synthetic click so the click handler below
-        // doesn't double-fire on touch devices.
+        // e.preventDefault() suppresses the synthetic click; _wireTapLastTouchAt provides
+        // a second guard in case preventDefault() is ignored by the WebView.
         this._tableEl.addEventListener('touchend', (e) => {
             const del = e.target.closest('.rt-delete-btn');
-            if (del) { e.preventDefault(); e.stopPropagation(); this._removeWaypoint(parseInt(del.dataset.idx)); return; }
+            if (del) { e.preventDefault(); e.stopPropagation(); _wireTapLastTouchAt = Date.now(); this._removeWaypoint(parseInt(del.dataset.idx)); return; }
             const demote = e.target.closest('.rt-demote-fuel-stop-btn');
-            if (demote) { e.preventDefault(); e.stopPropagation(); this._demoteFuelStop(parseInt(demote.dataset.idx)); return; }
+            if (demote) { e.preventDefault(); e.stopPropagation(); _wireTapLastTouchAt = Date.now(); this._demoteFuelStop(parseInt(demote.dataset.idx)); return; }
             const up = e.target.closest('.rt-up-btn');
-            if (up) { e.preventDefault(); e.stopPropagation(); this._moveWaypoint(parseInt(up.dataset.idx), parseInt(up.dataset.idx) - 1); return; }
+            if (up) { e.preventDefault(); e.stopPropagation(); _wireTapLastTouchAt = Date.now(); this._moveWaypoint(parseInt(up.dataset.idx), parseInt(up.dataset.idx) - 1); return; }
             const down = e.target.closest('.rt-down-btn');
-            if (down) { e.preventDefault(); e.stopPropagation(); this._moveWaypoint(parseInt(down.dataset.idx), parseInt(down.dataset.idx) + 1); return; }
+            if (down) { e.preventDefault(); e.stopPropagation(); _wireTapLastTouchAt = Date.now(); this._moveWaypoint(parseInt(down.dataset.idx), parseInt(down.dataset.idx) + 1); return; }
             const altCell = e.target.closest('.rt-alt-cell');
-            if (altCell && this._editMode) { e.preventDefault(); e.stopPropagation(); this._showAltPicker(parseInt(altCell.dataset.idx), altCell); return; }
+            if (altCell && this._editMode) { e.preventDefault(); e.stopPropagation(); _wireTapLastTouchAt = Date.now(); this._showAltPicker(parseInt(altCell.dataset.idx), altCell); return; }
             const pwr = e.target.closest('.rt-pwr-header');
-            if (pwr) { e.preventDefault(); e.stopPropagation(); this._cycleCruisePower(); return; }
+            if (pwr) { e.preventDefault(); e.stopPropagation(); _wireTapLastTouchAt = Date.now(); this._cycleCruisePower(); return; }
             const rules = e.target.closest('.rt-rules-header');
-            if (rules) { e.preventDefault(); e.stopPropagation(); this._toggleFlightRules(); return; }
+            if (rules) { e.preventDefault(); e.stopPropagation(); _wireTapLastTouchAt = Date.now(); this._toggleFlightRules(); return; }
             const row = e.target.closest('.rt-row');
             if (row) {
                 const idx = parseInt(row.dataset.idx);

--- a/web/shared/tap-utils.js
+++ b/web/shared/tap-utils.js
@@ -8,14 +8,18 @@
  * Do NOT use for Leaflet SVG polygon hit-testing — that uses a separate
  * touchstart/touchend pair on the map container with capture:true.
  */
+// Shared timestamp: after any wireTap touch fires, suppress synthetic click events
+// for 350ms on ALL wireTap elements. Prevents double-fire when _renderWaypoints()
+// rebuilds the DOM between touchend and the browser's synthetic click.
+let _wireTapLastTouchAt = 0;
+
 function wireTap(el, handler) {
     if (!el) return;
-    let tapStart = null, touchHandled = false;
+    let tapStart = null;
     el.addEventListener('touchstart', (e) => {
         if (e.touches.length === 1)
             tapStart = { x: e.touches[0].clientX, y: e.touches[0].clientY, t: Date.now() };
         else tapStart = null;
-        touchHandled = false;
     }, { passive: true });
     el.addEventListener('touchend', (e) => {
         if (!tapStart || e.changedTouches.length !== 1) { tapStart = null; return; }
@@ -24,11 +28,11 @@ function wireTap(el, handler) {
         const dy = e.changedTouches[0].clientY - ts.y;
         if (dx * dx + dy * dy > 400) return;
         if (Date.now() - ts.t > 500) return;
-        touchHandled = true;
+        _wireTapLastTouchAt = Date.now();
         handler(e);
     }, { passive: true });
     el.addEventListener('click', (e) => {
-        if (touchHandled) { touchHandled = false; return; }
+        if (Date.now() - _wireTapLastTouchAt < 350) return;
         handler(e);
     });
 }


### PR DESCRIPTION
## Summary

- **Bug 1 — accidental map waypoint insertion**: Removed the MAP+ button from the route editor and added guards in `app.js` so that tapping airport/navaid/fix markers on the map does nothing while the route editor panel is visible. The map is now read-only during editing.
- **Bug 2 — double-delete / unpredictable deletes**: Replaced the per-closure `touchHandled` flag in `wireTap` with a module-level timestamp. After any touch fires a handler, all `click` events on any `wireTap` element are suppressed for 350ms — immune to the DOM rebuild that `_renderWaypoints()` performs synchronously, which was causing the synthetic click to land on a newly created button at the same screen position with a fresh (unsuppressed) closure. Added the same timestamp guard to `route-table.js` as belt-and-suspenders.

## Root causes

**Bug 1**: MAP+ mode registered a one-shot Leaflet `click` handler that resolved the nearest airport within 5nm of *any* map tap point. An accidental touch on the map behind the editor panel (which doesn't cover the full screen) would fire it and insert an unintended waypoint.

**Bug 2**: `wireTap` uses `{ passive: true }` on `touchend` — cannot call `e.preventDefault()` — so the browser always generates a synthetic click ~150ms later. `_removeWaypoint()` → `_renderWaypoints()` rebuilds the entire waypoint list DOM. The synthetic click lands on the new button at the same position, whose fresh closure has `touchHandled = false`, firing a second delete with a shifted index.

## Test plan

- [ ] Open route editor with a multi-waypoint route — pan and zoom the map freely; no waypoints should be inserted
- [ ] With route editor open, tap an airport marker on the visible map portion — nothing should happen
- [ ] Delete a waypoint from the route editor list — only that waypoint should be removed
- [ ] Delete a waypoint from the route table (EDIT mode) — only that waypoint should be removed
- [ ] Rapid successive deletes — each tap removes exactly one waypoint
- [ ] Verify search, NEARBY, and route string parsing still add waypoints correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)