### PR TITLE
feat: FIS-B NEXRAD CONUS radar, approach altitude fix, fuel tank improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -297,6 +297,25 @@ curl http://localhost:9223/json   # should show title: "FlyTab", url: "http://lo
 ```
 Port 9222 is Chrome browser's DevTools — do not use it for FlyTab.
 
+### ADB — use the SDK binary, not the distro one
+
+There are two `adb` installs on this machine:
+
+| Path | Version | Use? |
+|------|---------|------|
+| `~/Android/Sdk/platform-tools/adb` | **36.x** | ✅ Always use this one |
+| `/usr/bin/adb` → `/usr/lib/android-sdk/...` | 34.0.4-debian | ❌ Stale, breaks wireless pairing |
+
+Whichever binary starts the server on port 5037 owns it. If the old **v34** server answers the v36 client, `adb pair` fails with `error: protocol fault (couldn't read status message): Success` — every time, instantly. This is NOT a bad code/port/IP; it's the version mismatch.
+
+**Before wireless pairing, force a clean v36 server:**
+```bash
+pkill -9 adb; sleep 1
+~/Android/Sdk/platform-tools/adb start-server
+~/Android/Sdk/platform-tools/adb pair <ip>:<pairing_port> <code>
+```
+Wireless-debugging pairing windows are single-use and short-lived — the code/port change every time the "Pair device with pairing code" dialog is reopened, and the pairing port closes after one attempt (success or fail). Have the fresh code/port ready and run `pair` immediately. After a successful pair, mDNS auto-connects (`adb devices` shows the device as `device`); no separate `adb connect` needed. The tablet (TB520FU) is on DHCP — its IP drifts (seen at .62/.63), so confirm the current IP rather than assuming.
+
 ## Key Conventions
 
 - **Versioning**: The app version lives at the top of `web/app.js`. `build.sh` reads it and sets `versionCode`/`versionName` in `build.gradle` automatically.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "app.flywhere.flytab"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 938
-        versionName "9.38"
+        versionCode 939
+        versionName "9.39"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "app.flywhere.flytab"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 922
-        versionName "9.22"
+        versionCode 938
+        versionName "9.38"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.

--- a/docs/bug-list.md
+++ b/docs/bug-list.md
@@ -1,0 +1,65 @@
+# FlyTab Bug List
+
+Running list of bugs found from screenshot/flight review. Newest review at top.
+Each item notes the source screenshot, confidence, and a likely root-cause pointer where known.
+
+---
+
+## Today's flight — 2026-05-29 (app v9.26)
+
+Sim/replay flight: KLKR → KGRD planned, then an approach back into KLKR.
+Screenshots in `screenshots/Screenshot_20260529-*.png`.
+
+### A. ~~CRITICAL~~ — **FIXED v9.34** — False engine-anomaly emergency alert during the landing flare (14 ft AGL)
+- **Source:** `Screenshot_20260529-114025.png`
+- Full-screen red **"ENGINE ANOMALY CONFIRMED — No airports within glide range. Declare emergency — squawk 7700."** fired at **14 ft AGL** while landing at the destination (KLKR).
+- **Root cause (confirmed):** `_checkEmergencyTrigger` in `web/cockpit/engine-ml.js` had no AGL lower bound. Throttle-to-idle in the landing flare produces the same physics-rule signatures as a total engine failure (MAP drop >5", RPM drop >300 RPM), the ML model flags the transition as anomalous (window built during the approach power setting), and `_hasLaunched` stays `true` because groundspeed is still >30 kts at 14 ft AGL — so the existing ground guard misses the flare.
+- **Fix:** Added AGL guard at the top of the joint trigger: compute AGL from `_altHistory`/`_fieldElev`; suppress if AGL < 500 ft. Below 500 ft the pilot is committed regardless; a false 7700 call during the flare is dangerous noise. Genuine failures at pattern altitude (≥500 ft) still trigger. Verified: CDP test confirmed 14 ft suppressed, 1500 ft fires.
+- **Commit:** `web/cockpit/engine-ml.js`
+
+### B. ~~HIGH~~ — **FIXED v9.34** (consequence of A) — "0 airports within 0 nm glide range" while landing AT an airport
+- **Source:** `Screenshot_20260529-114025.png` (same alert)
+- `EmergencyGlide.trigger()` computed glide range as `14 ft × 10 / 6076 = 0.0 nm` → 0 airports found. This was entirely a consequence of Bug A firing at 14 ft AGL. With Bug A suppressed below 500 ft AGL, Bug B never occurs.
+
+### C. MEDIUM (reproducible) — Route table per-phase TIME values don't sum to the leg/total
+- **Sources:** `Screenshot_20260529-101410.png` (KLKR→KGRD: CLB 26m + CRZ 12m + DES 10m = 48m, but TOTAL 26m / header 30m); `Screenshot_20260529-111005.png` (CORON→KLKR: CLB 9m + CRZ 5m = 14m, TOTAL 9m).
+- The climb/cruise/descent phase sub-rows show times that exceed the leg/total time. A 26-min climb on a 70 nm leg is also implausible. FUEL columns sum correctly; only TIME is wrong.
+- **Likely area:** per-phase time computation in `web/cockpit/route-table.js` profile builder (`_buildProfileData`).
+
+### D. MEDIUM — Degenerate approach altitude profile (cruise altitude shown as 50 ft)
+- **Sources:** `Screenshot_20260529-111005.png`, `-111306.png`, `-111514.png`
+- After loading the CORON→RW06→KLKR approach, the profile shows **CLB 0→50, CRZ 50, DES 50→0** — a 24 nm leg "cruising" at 50 ft, while the aircraft is actually at ~4,500 ft. Origin CORON altitude shows 0.
+- The altitude profile for the approach/return leg isn't being computed (defaulting to a 50 ft floor).
+- **Likely area:** altitude/profile assignment when an approach is loaded as the active route.
+
+### E. ~~LOW~~ — **FIXED v9.33** — FIS-B towers show "-999 dB" sentinel as a literal signal value
+- **Source:** `Screenshot_20260529-110503.png` (FIS-B status page)
+- Towers with 0 messages/min displayed **"-999 dB"** in red; additionally they sorted to the top of the list (old sort: `-999 || 0 = 0`).
+- **Fix:** `_renderTowers` in `web/cockpit/fisb-status.js` — values ≤ −100 display `—` (no dB suffix), sort to the bottom. Verified via CDP with injected mock tower data.
+
+### F. BUG — Fuel-below-reserve warning fires incorrectly on a short leg
+- **Source:** `Screenshot_20260529-101155.png`
+- Route planner warns "Fuel below reserve: -2.0 gal at dest, 10 gal reserve required" on a 70 nm / 3.7 gal route starting with ~26.6 gal on board. With 3.7 gal used, ~22.9 gal would remain — far above the 10 gal reserve threshold. The warning should NOT fire.
+- **Reclassified** from INVESTIGATE to BUG: the math is clear, the reserve check is wrong (likely using stale, incorrect, or zero starting fuel figure).
+- **Likely area:** fuel-reserve calculation in the route planner — check what starting fuel value the reserve check reads.
+
+### Possible / low-confidence (worth a glance, not confirmed)
+- Flight phase shows **"STARTUP"** after landing while stopped on the ground (`-114405/-114418/-114613/-114652/-114700`) — phase detector may mislabel a stopped-after-landing state.
+- Dense ADS-B traffic labels overlap into an unreadable cluster in a high-traffic area (`-110406.png`).
+- Fuel-gauge overlay total (~28 gal) vs TIC entry total (26.6 gal) — minor mismatch (`-101604.png` vs `-101555.png`).
+
+---
+
+## Earlier review — 2026-05-28 (app v9.23)
+
+Screenshot: `screenshots/Screenshot_20260528-143757.png` (route table, KLKR route).
+Two other shots that day (`-163252` LAYERS panel, `-163322` MORE drawer) showed no visible bugs.
+
+### 1. HIGH — Route summary header shows the wrong destination (stale)
+- Header + destination search box show **KMHT** (729 nm / 5:12 / 40.8 g / DEST:34.0), but the flight strip says **KLKR → KDMW** and the footer shows **DEST 383 nm / ETE 2:44** — which matches a KDMW route at 140 kt cruise.
+- Corroborating: header `DEST:34.0` (fuel at destination) is *higher* than the first leg's REM (30.1, declining) — impossible for the final destination.
+- **Likely root cause:** `web/cockpit/route-table.js:236-237` builds the header from `plan.flight_plan?.destination` (stale KMHT) and only falls back to `plan.waypoints[last].icao` (current KDMW) when that's null. When the destination changes, the waypoint array is rebuilt but `flight_plan.destination` isn't. Matches the `_lastPlan` / state-lifecycle hazard noted in CLAUDE.md.
+
+### 2. MEDIUM — Climb-leg row: ALT column overlaps HDG/BRG
+- On the active CLB leg the climb-altitude range string ("486 → 7,000 ↑1,500") is too wide for the ALT column and collides with the HDG/BRG values. Other rows render cleanly.
+- **Note:** likely still present in v9.26 — today's shots show the climb-rate annotation truncated ("↑1,5") in the same column.

--- a/docs/superpowers/plans/2026-05-29-fisb-nexrad-conus-radar-page.md
+++ b/docs/superpowers/plans/2026-05-29-fisb-nexrad-conus-radar-page.md
@@ -1,0 +1,953 @@
+# FIS-B NEXRAD Regional/CONUS Split + CONUS Radar Page — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop FIS-B CONUS NEXRAD from painting oversized squares on the main map, and give CONUS its own zoomed-out radar page with ownship + loop, while wiring up the provisioned-but-dead `radar.cacheHours` frame persistence so frames survive restart and can be exported for ground testing.
+
+**Architecture:** `FisbNexrad` becomes the single data layer (block store + frame history, blocks tagged with `Radar_Type`/`Scale`). Rendering is parameterized by a `{map,canvas,ctx}` target + a product filter (`'regional'`/`'conus'`). The main map renders Regional only; a new `RadarPage` (its own Leaflet map) renders CONUS only. Both animate via a target-aware `RadarLoop`. Frames persist to IndexedDB for `cacheHours` and can be exported as NDJSON and replayed through `mock-stratux.py`.
+
+**Tech Stack:** Vanilla JS (no bundler; `<script>` tags in `web/index.html`), Leaflet, Canvas 2D, IndexedDB, Python `mock-stratux.py`. Build via `bash build.sh` (bump `FLYTAB_VERSION` in `web/app.js` first).
+
+**Spec:** `docs/superpowers/specs/2026-05-29-fisb-nexrad-conus-radar-page-design.md`
+
+---
+
+## Testing reality (read first)
+
+Cockpit JS has **no automated test harness** (only `web/shared/planning/` has vitest). So:
+- The **pure** `_productOf` classifier gets a standalone Node assertion (Task 2) — the one true unit test.
+- Everything else is verified **on the tablet** against `mock-stratux.py`, which Task 1 teaches to emit synthetic Regional+CONUS NEXRAD. Build the harness first so every later task is verifiable on the ground.
+- Tablet is reachable over ADB at the SDK path (`~/Android/Sdk/platform-tools/adb`); CDP inspect via `adb forward tcp:9223 localabstract:webview_devtools_remote_$(adb shell pidof app.flywhere.flytab)`.
+- **Tap Handler Regression Rule (CLAUDE.md):** after any map-touching task, manually confirm tapping an airport on the **main** map still opens its popup.
+
+## File structure
+
+| File | Create/Modify | Responsibility |
+|---|---|---|
+| `tools/mock-stratux.py` | Modify | Emit synthetic Regional+CONUS NEXRAD time-series on `/jsonio`; `--replay-nexrad` mode |
+| `tools/test-productof.mjs` | Create | Node unit test for the product classifier |
+| `web/cockpit/fisb-nexrad.js` | Modify | Tag blocks w/ product; product-aware `draw(target,product)`; per-product age; config wiring; IDB persistence + export |
+| `web/cockpit/radar-page.js` | Create | CONUS full-screen page: own map, ownship, CONUS canvas, zoom/recenter, badge, loop |
+| `web/cockpit/radar-loop.js` | Modify | Target-aware playback (`{renderer,target,product}`) |
+| `web/cockpit/map.js` | Modify | Main map renders Regional only; Regional age badge |
+| `web/cockpit/tab-bar.js` | Modify | MORE → In-flight "Radar" item |
+| `web/app.js` | Modify | Instantiate `RadarPage`, wire into TabBar; bump version |
+| `web/index.html` | Modify | `<script>` tag for `radar-page.js` |
+| `web/style.css` | Modify | Radar page + badge styles (tokens only) |
+| `web/cockpit-config.js` (defaults) | Modify | none new — wire existing `radar.*` |
+
+---
+
+## PHASE 1 — Harness, data model, render split, main-map fix + badge
+
+### Task 1: Synthetic NEXRAD emitter in `mock-stratux.py`
+
+**Files:**
+- Modify: `tools/mock-stratux.py`
+
+- [ ] **Step 1: Add NEXRAD block builder + emitter**
+
+Add near the top (after the imports / ownship constants), using the verified `nexrad.go` geometry (`BLOCK_HEIGHT=4/60`, `BLOCK_WIDTH=48/60`, regional realScale 1, CONUS scale 1 → realScale 5):
+
+```python
+# --- Synthetic FIS-B NEXRAD ---------------------------------------------
+BLOCK_H = 4.0 / 60.0          # 0.0667 deg lat
+BLOCK_W = 48.0 / 60.0         # 0.8 deg lon
+
+def _nexrad_block(lat_n, lon_w, scale, intensities):
+    """One NEXRADBlock in Stratux /jsonio shape."""
+    real = {0: 1.0, 1: 5.0, 2: 9.0}[scale]
+    return {
+        "Radar_Type": 63 if scale == 0 else 64,
+        "Scale": scale,
+        "LatNorth": round(lat_n, 4),
+        "LonWest": round(lon_w, 4),
+        "Height": round(BLOCK_H * real, 4),
+        "Width": round(BLOCK_W * real, 4),
+        "Intensity": intensities,           # list[int] length 128 (32x4)
+    }
+
+def _gradient_cell(seed):
+    """128-bin (32x4) intensity grid: a moving blob of levels 1..6."""
+    out = []
+    for r in range(4):
+        for c in range(32):
+            d = abs(c - (seed % 32)) + abs(r - 2)
+            out.append(max(0, 6 - d) if d <= 6 else 0)
+    return out
+
+def nexrad_frame(tick):
+    """Return a Stratux UATFrame-shaped dict with Regional + CONUS blocks.
+    Cells drift east with tick so the loop animates."""
+    seed = tick % 32
+    regional = [
+        _nexrad_block(OWN_LAT + 0.5,  OWN_LON - 0.4 + 0.05*seed, 0, _gradient_cell(seed)),
+        _nexrad_block(OWN_LAT + 0.43, OWN_LON - 0.4 + 0.05*seed, 0, _gradient_cell(seed+4)),
+    ]
+    # CONUS: scale-1 blocks (0.333 x 4.0 deg) spread across the Southeast
+    conus = []
+    for i in range(3):
+        conus.append(_nexrad_block(35.0 + 0.33*i, -84.0 + 4.0 + 0.2*seed, 1,
+                                   _gradient_cell(seed + i*3)))
+    return {"Product_id": 63, "NEXRAD": regional + conus,
+            "LocaltimeReceived": time.strftime("%Y-%m-%dT%H:%M:%S")}
+```
+
+- [ ] **Step 2: Broadcast it on the `/jsonio` channel each tick**
+
+Find the per-client send loop (the one that emits traffic/situation as JSON over the websocket). Add, once per ~5 s tick (use the existing tick counter; if none, add `tick = 0` and increment):
+
+```python
+        await ws.send(json.dumps(nexrad_frame(tick)))
+```
+
+Emit it on the same socket the app reads for `/jsonio`/weather. If the mock serves channels by path, send `nexrad_frame` on the `/jsonio` handler; otherwise send on the shared JSON socket (the app's `stratux-client.js` discriminates by the presence of `msg.NEXRAD`).
+
+- [ ] **Step 3: Run the mock and confirm frames go out**
+
+Run: `python3 tools/mock-stratux.py --port 5678`
+Expected: starts without error; log shows ticks. (Visual confirmation happens in Task 3 once the app renders it.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tools/mock-stratux.py
+git commit -m "test(radar): mock-stratux emits synthetic Regional+CONUS NEXRAD"
+```
+
+---
+
+### Task 2: Tag blocks with product + `_productOf` classifier
+
+**Files:**
+- Modify: `web/cockpit/fisb-nexrad.js:160-212` (`_handleNexrad`), add static `_productOf`
+- Create: `tools/test-productof.mjs`
+
+- [ ] **Step 1: Write the failing classifier test**
+
+Create `tools/test-productof.mjs`:
+
+```js
+import assert from 'node:assert';
+// Mirror of FisbNexrad._productOf (kept in sync; pure function).
+const productOf = (b) => (b.radarType === 64 || b.scale > 0) ? 'conus' : 'regional';
+
+assert.equal(productOf({ radarType: 63, scale: 0 }), 'regional');
+assert.equal(productOf({ radarType: 64, scale: 1 }), 'conus');
+assert.equal(productOf({ radarType: 63, scale: 1 }), 'conus'); // scale wins
+assert.equal(productOf({ radarType: 64, scale: 0 }), 'conus'); // type wins
+console.log('OK productOf');
+```
+
+- [ ] **Step 2: Run it (passes as a spec of intent)**
+
+Run: `node tools/test-productof.mjs`
+Expected: `OK productOf`
+
+- [ ] **Step 3: Add `_productOf` + per-product age + keep fields in `_handleNexrad`**
+
+In `fisb-nexrad.js`, add a static method:
+
+```js
+    /** Classify a stored block by FIS-B product. */
+    static _productOf(block) {
+        return (block.radarType === 64 || block.scale > 0) ? 'conus' : 'regional';
+    }
+```
+
+In the constructor add per-product freshness:
+
+```js
+        this._newestAt = { regional: 0, conus: 0 };
+```
+
+In `_handleNexrad`, replace the stored-block object and add age tracking:
+
+```js
+        for (const block of blocks) {
+            if (!block.Intensity || block.Intensity.length === 0) continue;
+
+            const key = `${block.LatNorth},${block.LonWest}`;
+            const stored = {
+                latN: block.LatNorth,
+                lonW: block.LonWest,
+                height: block.Height,
+                width: block.Width,
+                intensity: block.Intensity,
+                radarType: block.Radar_Type,   // 63 Regional | 64 CONUS
+                scale: block.Scale,             // 0 | 1 | 2
+                received_at: now,
+            };
+            this._blocks.set(key, stored);
+            const p = FisbNexrad._productOf(stored);
+            if (now > this._newestAt[p]) this._newestAt[p] = now;
+        }
+```
+
+- [ ] **Step 4: Build**
+
+Bump `FLYTAB_VERSION` in `web/app.js` (e.g. `v9.27`), then `bash build.sh`.
+Expected: build succeeds; APK copied to `data/`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/cockpit/fisb-nexrad.js web/app.js tools/test-productof.mjs
+git commit -m "feat(radar): tag NEXRAD blocks with product + per-product age"
+```
+
+---
+
+### Task 3: Product-aware render targets; main map = Regional only
+
+**Files:**
+- Modify: `web/cockpit/fisb-nexrad.js` (`addTo`, `_draw`, `drawFrame`, add `_drawToTarget`, `draw`)
+
+- [ ] **Step 1: Store the main map as a target in `addTo`**
+
+In `addTo(map)`, after creating `this._canvas`/`this._ctx`, add:
+
+```js
+        this._mainTarget = { map, canvas: this._canvas, ctx: this._ctx };
+```
+
+- [ ] **Step 2: Extract `_drawToTarget` and a public `draw`**
+
+Replace the body of `_draw()` with a delegation, and add the generalized methods. `_drawBlock` is unchanged.
+
+```js
+    /** Public: draw current blocks of one product to a target. */
+    draw(target, product) {
+        this._drawToTarget(target, product, this._blocks);
+    }
+
+    /** Draw a block map (live or snapshot) of one product onto a target's canvas. */
+    _drawToTarget(target, product, blockMap) {
+        const { map, canvas, ctx } = target;
+        if (!ctx || !map) return;
+
+        const topLeft = map.containerPointToLayerPoint([0, 0]);
+        canvas.style.transform = `translate(${topLeft.x}px, ${topLeft.y}px)`;
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        if (blockMap.size === 0) return;
+
+        ctx.globalAlpha = this._opacity;
+        const bounds = map.getBounds();
+        const zoom = map.getZoom();
+
+        for (const [, block] of blockMap) {
+            if (FisbNexrad._productOf(block) !== product) continue;
+            const blockS = block.latN - block.height;
+            const blockE = block.lonW + block.width;
+            if (block.latN < bounds.getSouth() || blockS > bounds.getNorth()) continue;
+            if (blockE < bounds.getWest() || block.lonW > bounds.getEast()) continue;
+            this._drawBlock(ctx, map, block, zoom);
+        }
+        ctx.globalAlpha = 1.0;
+    }
+```
+
+- [ ] **Step 3: Point the main-map live draw at Regional only**
+
+Replace `_draw()` with:
+
+```js
+    /** Draw the main-map live view — Regional product only. */
+    _draw() {
+        if (!this._active || !this._mainTarget) return;
+        this._drawToTarget(this._mainTarget, 'regional', this._blocks);
+    }
+```
+
+- [ ] **Step 4: Make `drawFrame` target+product aware**
+
+Change the signature and body:
+
+```js
+    /** Draw a specific historical frame of one product onto a target (radar loop). */
+    drawFrame(target, product, frameIndex) {
+        if (frameIndex < 0 || frameIndex >= this._frameHistory.length) return;
+        const snap = this._frameHistory[frameIndex];
+        if (!snap) return;
+        this._drawToTarget(target, product, snap.blocks);
+    }
+```
+
+Update the existing call site `drawLive()` to remain `this._draw()`. (RadarLoop call sites are updated in Task 5.)
+
+- [ ] **Step 5: Build + verify on tablet against the mock**
+
+`bash build.sh`; install; set `simMode:true`, `simBridgePort:5678` in config; start `python3 tools/mock-stratux.py`; enable NEXRAD layer.
+Expected: only the small Regional gradient cells paint near ownship; the large CONUS rectangles do **not** appear on the map. Tap an airport → popup still opens (regression check).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/cockpit/fisb-nexrad.js
+git commit -m "feat(radar): product-aware render targets; main map shows Regional only"
+```
+
+---
+
+### Task 4: Product + age badge on the main map
+
+**Files:**
+- Modify: `web/cockpit/fisb-nexrad.js` (add `getDataAgeMs(product)`)
+- Modify: `web/cockpit/map.js` (badge element + update tick)
+- Modify: `web/style.css` (badge style, tokens only)
+
+- [ ] **Step 1: Per-product age accessor**
+
+In `fisb-nexrad.js` replace `getDataAgeMs()` with a product-aware version (keep a no-arg fallback for existing callers):
+
+```js
+    getDataAgeMs(product) {
+        if (product) {
+            const t = this._newestAt[product];
+            return t ? Date.now() - t : null;
+        }
+        return this._latestDataTime ? Date.now() - this._latestDataTime : null;
+    }
+```
+
+- [ ] **Step 2: Add the badge to the map**
+
+In `map.js`, where the NEXRAD layer is toggled on (`_radarLayer`/`_fisbNexrad.addTo`), create a badge element if absent and start a 30 s updater:
+
+```js
+    _updateRadarBadge() {
+        if (!this._fisbNexrad) return;
+        const el = this._radarBadge || (this._radarBadge = (() => {
+            const d = document.createElement('div');
+            d.className = 'radar-badge';
+            this.container.appendChild(d);
+            return d;
+        })());
+        const ageMs = this._fisbNexrad.getDataAgeMs('regional');
+        if (ageMs == null) { el.style.display = 'none'; return; }
+        const min = Math.round(ageMs / 60000);
+        el.style.display = 'block';
+        el.textContent = `FIS-B · Regional · ${min} min`;
+    }
+```
+
+Call `this._updateRadarBadge()` when radar enables, on `fisb:nexrad`, and on a 30 s interval; hide/remove it when radar is disabled.
+
+- [ ] **Step 3: Style the badge (tokens only)**
+
+In `style.css`:
+
+```css
+.radar-badge {
+    position: absolute; bottom: 8px; left: 8px; z-index: 500;
+    background: var(--bg-surface); color: var(--text-secondary);
+    border: 1px solid var(--border); border-radius: 6px;
+    padding: 4px 8px; font-family: var(--font-ui); font-weight: 700;
+    font-size: 13px; pointer-events: none;
+}
+```
+
+- [ ] **Step 4: Build + verify**
+
+`bash build.sh`; run mock; enable NEXRAD.
+Expected: badge reads `FIS-B · Regional · <n> min`; hidden when no data / radar off.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/cockpit/fisb-nexrad.js web/cockpit/map.js web/style.css web/app.js
+git commit -m "feat(radar): main-map FIS-B Regional product + age badge"
+```
+
+---
+
+## PHASE 2 — CONUS radar page + loops + drawer
+
+### Task 5: Target-aware `RadarLoop`
+
+**Files:**
+- Modify: `web/cockpit/radar-loop.js`
+
+- [ ] **Step 1: Accept a target + product; default to main map / Regional**
+
+In the constructor add:
+
+```js
+        this._target  = opts.target  || null;     // {map,canvas,ctx}; null → renderer's main target
+        this._product = opts.product || 'regional';
+```
+
+Change the signature to `constructor(opts = {})`. Where the loop renders a frame, replace the `_fisbRenderer.drawFrame(i)` / `_nexrad.drawFrame(i)` calls with:
+
+```js
+        const target = this._target || this._fisbRenderer?._mainTarget;
+        if (target) this._fisbRenderer.drawFrame(target, this._product, i);
+```
+
+(For the internet source path, keep its existing `drawFrame(i)` — internet frames are main-map only and unaffected.)
+
+- [ ] **Step 2: Build + verify the main-map loop still animates**
+
+`bash build.sh`; run mock (it emits a moving cell); enable NEXRAD; let ~2 frames accumulate or press play on the loop control.
+Expected: Regional cells animate east; no CONUS on the map.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web/cockpit/radar-loop.js
+git commit -m "feat(radar): target-aware RadarLoop playback"
+```
+
+---
+
+### Task 6: `RadarPage` — CONUS view
+
+**Files:**
+- Create: `web/cockpit/radar-page.js`
+- Modify: `web/index.html` (script tag, after `fisb-nexrad.js` and before `app.js`)
+- Modify: `web/style.css` (page styles)
+- Modify: `web/shared/cockpit-config.js` defaults (`radar.conusDefaultZoom: 6`)
+
+- [ ] **Step 1: Add config default**
+
+In `cockpit-config.js` `radar` defaults add: `conusDefaultZoom: 6,`
+
+- [ ] **Step 2: Create the page**
+
+`web/cockpit/radar-page.js`:
+
+```js
+/**
+ * FlyTab — CONUS Radar Page
+ * Full-screen dedicated FIS-B CONUS NEXRAD view: own Leaflet map, ownship icon,
+ * SE-wide default zoom, pan/zoom + recenter, product/age badge, CONUS loop.
+ * Reuses the shared FisbNexrad data layer (renders product 'conus' to its own target).
+ */
+class RadarPage {
+    constructor(fisbNexrad, stratuxClient) {
+        this._fisb = fisbNexrad;
+        this._stratux = stratuxClient;
+        this._visible = false;
+        this._map = null;
+        this._canvas = null;
+        this._ctx = null;
+        this._target = null;
+        this._ownship = null;
+        this._ownPos = null;            // last {lat,lon,course}
+        this._badge = null;
+        this._loop = null;
+        this._ageTimer = null;
+        this._defaultZoom = (CockpitConfig.get('radar.conusDefaultZoom')) || 6;
+
+        this._onSituation = (e) => this._updateOwnship(e.detail);
+        this._onNexrad = () => { if (this._visible) { this._drawConus(); this._updateBadge(); } };
+        this._buildDom();
+    }
+
+    _buildDom() {
+        this._el = document.createElement('div');
+        this._el.className = 'radar-page';
+        this._el.style.display = 'none';
+        this._el.innerHTML = `
+            <div class="radar-page-header">
+                <span class="radar-page-title">CONUS Radar</span>
+                <span class="radar-badge radar-page-badge"></span>
+                <button class="radar-page-close" aria-label="Close">&#x2715;</button>
+            </div>
+            <div class="radar-page-map"></div>
+            <button class="radar-page-recenter">Recenter on me</button>`;
+        document.body.appendChild(this._el);
+        this._mapEl = this._el.querySelector('.radar-page-map');
+        this._badge = this._el.querySelector('.radar-page-badge');
+        this._el.querySelector('.radar-page-close')
+            .addEventListener('click', () => this.hide());
+        this._el.querySelector('.radar-page-recenter')
+            .addEventListener('click', () => this._recenter());
+    }
+
+    _ensureMap() {
+        if (this._map) return;
+        const tileBase = 'http://localhost:9090/tiles';
+        this._map = L.map(this._mapEl, { zoomControl: true, attributionControl: false });
+        L.tileLayer(`${tileBase}/sectional/{z}/{x}/{y}.webp`,
+            { minZoom: 4, maxZoom: 14 }).addTo(this._map);
+
+        // CONUS canvas overlay in the map's overlay pane
+        this._canvas = document.createElement('canvas');
+        this._canvas.style.cssText = 'position:absolute;top:0;left:0;pointer-events:none;';
+        this._map.getPanes().overlayPane.appendChild(this._canvas);
+        this._ctx = this._canvas.getContext('2d');
+        this._target = { map: this._map, canvas: this._canvas, ctx: this._ctx };
+
+        const size = () => {
+            const s = this._map.getSize();
+            this._canvas.width = s.x * 2; this._canvas.height = s.y * 2;
+        };
+        size();
+        this._map.on('resize', () => { size(); this._drawConus(); });
+        this._map.on('move zoom moveend zoomend', () => this._drawConus());
+    }
+
+    _drawConus() {
+        if (this._target) this._fisb.draw(this._target, 'conus');
+    }
+
+    _updateOwnship(sit) {
+        if (!sit || sit.lat == null || sit.lon == null) return;
+        this._ownPos = { lat: sit.lat, lon: sit.lon, course: sit.true_course || 0 };
+        if (!this._visible || !this._map) return;
+        const pos = [sit.lat, sit.lon];
+        if (!this._ownship) {
+            const icon = L.divIcon({ className: 'ownship-icon',
+                html: CockpitMap._ownshipSvg(0), iconSize: [48, 48], iconAnchor: [24, 24] });
+            this._ownship = L.marker(pos, { icon, zIndexOffset: 1000 }).addTo(this._map);
+        } else {
+            this._ownship.setLatLng(pos);
+        }
+        const g = this._ownship.getElement()?.querySelector('svg g');
+        if (g) g.setAttribute('transform', `rotate(${this._ownPos.course}, 24, 24)`);
+    }
+
+    _recenter() {
+        if (this._ownPos && this._map)
+            this._map.setView([this._ownPos.lat, this._ownPos.lon], this._defaultZoom);
+    }
+
+    _updateBadge() {
+        const ageMs = this._fisb.getDataAgeMs('conus');
+        if (ageMs == null) { this._badge.textContent = 'FIS-B · CONUS · no data'; return; }
+        this._badge.textContent = `FIS-B · CONUS · ${Math.round(ageMs / 60000)} min`;
+    }
+
+    isVisible() { return this._visible; }
+
+    show() {
+        this._visible = true;
+        this._el.style.display = 'flex';
+        this._ensureMap();
+        // Leaflet needs a size recalc after the container becomes visible
+        setTimeout(() => { this._map.invalidateSize(); this._recenter(); this._drawConus(); }, 0);
+        this._stratux.addEventListener('stratux:situation', this._onSituation);
+        this._fisb.addEventListener?.('fisb:nexrad', this._onNexrad); // FisbNexrad re-dispatch
+        if (this._ownPos) this._updateOwnship({ lat: this._ownPos.lat, lon: this._ownPos.lon, true_course: this._ownPos.course });
+        this._updateBadge();
+        this._ageTimer = setInterval(() => this._updateBadge(), 30000);
+    }
+
+    hide() {
+        this._visible = false;
+        this._el.style.display = 'none';
+        this._stratux.removeEventListener('stratux:situation', this._onSituation);
+        this._fisb.removeEventListener?.('fisb:nexrad', this._onNexrad);
+        if (this._loop) this._loop.stop?.();
+        if (this._ageTimer) { clearInterval(this._ageTimer); this._ageTimer = null; }
+    }
+}
+```
+
+Note: `FisbNexrad` already extends `EventTarget` (it dispatches `fisb:nexrad`? — verify; if not, subscribe to `this._stratux`'s `stratux:nexrad` instead and call `_drawConus`). If `FisbNexrad` does not emit `fisb:nexrad`, change the `_onNexrad` subscription in `show()`/`hide()` to `this._fisb._fisb` (the FisbClient) `fisb:nexrad`, which it already listens to.
+
+- [ ] **Step 3: Add the script tag**
+
+In `web/index.html`, after the `fisb-nexrad.js` tag:
+
+```html
+    <script src="cockpit/radar-page.js"></script>
+```
+
+- [ ] **Step 4: Style the page (tokens only, light theme — do NOT set data-mode)**
+
+In `style.css`:
+
+```css
+.radar-page { position: fixed; inset: 0; z-index: 4000; background: var(--bg-primary);
+    display: flex; flex-direction: column; }
+.radar-page-header { display: flex; align-items: center; gap: 12px;
+    padding: 8px 12px; border-bottom: 2px solid var(--border-strong); }
+.radar-page-title { font-family: var(--font-ui); font-weight: 800;
+    font-size: 18px; color: var(--text-primary); }
+.radar-page-close { margin-left: auto; min-width: var(--touch-min, 56px);
+    min-height: var(--touch-min, 56px); font-size: 24px; font-weight: 800;
+    background: var(--bg-surface); border: 1px solid var(--border); border-radius: 8px; }
+.radar-page-map { flex: 1; position: relative; }
+.radar-page-recenter { position: absolute; bottom: 16px; right: 16px; z-index: 500;
+    min-height: var(--touch-preferred, 64px); padding: 0 18px;
+    font-family: var(--font-ui); font-weight: 800; font-size: 16px;
+    color: #fff; background: var(--accent); border: none; border-radius: 10px; }
+.radar-page-badge { position: static; }
+```
+
+- [ ] **Step 5: Wire into app + drawer (deferred to Task 8); build + smoke**
+
+Temporarily expose for testing: after `this.fisbNexrad = ...` in `app.js`, add `this.radarPage = new RadarPage(this.fisbNexrad, this.stratuxClient);` (full wiring in Task 8). `bash build.sh`.
+Expected: no console errors at startup; page class loads.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/cockpit/radar-page.js web/index.html web/style.css web/shared/cockpit-config.js web/app.js
+git commit -m "feat(radar): CONUS RadarPage (own map, ownship, zoom/recenter, badge)"
+```
+
+---
+
+### Task 7: CONUS loop on the radar page
+
+**Files:**
+- Modify: `web/cockpit/radar-page.js`
+
+- [ ] **Step 1: Build a CONUS loop bound to the page target**
+
+In `RadarPage` constructor, after `_buildDom()`:
+
+```js
+        this._loop = new RadarLoop({ target: this._target, product: 'conus' });
+```
+
+Move this to `_ensureMap()` end (target exists there). Set its renderer:
+
+```js
+        this._loop.setFisbRenderer(this._fisb);
+        this._loop.setNexrad(this._fisb);
+        this._mapEl.parentNode.appendChild(this._loop._controlEl); // show the loop control on the page
+```
+
+- [ ] **Step 2: Start/stop the loop with the page**
+
+In `show()` after the map recalc add `this._loop?.show?.(this._map);` and in `hide()` ensure `this._loop?.hide?.()` (or `.stop()`), matching RadarLoop's actual show/hide API (read `radar-loop.js`).
+
+- [ ] **Step 3: Build + verify**
+
+`bash build.sh`; run mock (moving CONUS cells); open the page.
+Expected: CONUS blocks paint at SE-wide zoom; loop control animates them eastward; ownship visible; recenter works.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/cockpit/radar-page.js
+git commit -m "feat(radar): CONUS loop on the radar page"
+```
+
+---
+
+### Task 8: MORE drawer entry + app wiring
+
+**Files:**
+- Modify: `web/app.js` (instantiate after FisbNexrad; add to TabBar components)
+- Modify: `web/cockpit/tab-bar.js` (In-flight item)
+
+- [ ] **Step 1: Instantiate + pass to TabBar**
+
+In `app.js`, ensure `this.radarPage = new RadarPage(this.fisbNexrad, this.stratuxClient);` is created after `this.fisbNexrad`. In the `new TabBar({...})` components object add: `radarPage: this.radarPage,`
+
+- [ ] **Step 2: Add the drawer item**
+
+In `tab-bar.js` `_buildMoreDrawer()`, after the Approach Charts item (line ~173):
+
+```js
+            { icon: '🌧', label: 'Radar', action: () => {
+                c.radarPage?.show();
+                this._hideRadarControls();
+                this._closeMoreDrawer();
+            }},
+```
+
+- [ ] **Step 3: Build + verify end-to-end**
+
+`bash build.sh`; run mock; MORE → Radar.
+Expected: page opens to SE-wide CONUS view with ownship + loop + badge; close returns to map; main map still Regional-only; airport tap on main map still works.
+
+- [ ] **Step 4: Update user manual**
+
+Add a "Radar (CONUS)" entry under the MORE/In-flight section of `docs/user-manual.md` describing the page, recenter, and loop.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/app.js web/cockpit/tab-bar.js docs/user-manual.md
+git commit -m "feat(radar): launch CONUS radar page from MORE drawer"
+```
+
+---
+
+## PHASE 3 — Frame persistence + export (`radar.cacheHours`)
+
+### Task 9: Wire `radar.*` config into `FisbNexrad`
+
+**Files:**
+- Modify: `web/cockpit/fisb-nexrad.js` (constructor + snapshot cadence)
+
+- [ ] **Step 1: Read config in the constructor**
+
+Replace the hardcoded `this._maxFrames = 24;` with:
+
+```js
+        const intervalMin = CockpitConfig.get('radar.frameIntervalMinutes') || 10;
+        const durationHr  = CockpitConfig.get('radar.loopDurationHours') || 2;
+        this._cacheHours  = CockpitConfig.get('radar.cacheHours') || 3;
+        this._snapIntervalMs = intervalMin * 60000;
+        this._maxFrames = Math.max(2, Math.ceil(durationHr * 60 / intervalMin));
+```
+
+- [ ] **Step 2: Use the configured cadence for snapshots**
+
+In `_handleNexrad`, replace the hardcoded `150000` with `this._snapIntervalMs`.
+
+- [ ] **Step 3: Build + verify cadence unchanged behaviorally**
+
+`bash build.sh`; run mock; confirm frames still accumulate (with defaults 10 min this is slow — temporarily set `frameIntervalMinutes:1` in config to verify accumulation, then revert).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/cockpit/fisb-nexrad.js
+git commit -m "feat(radar): wire radar.frameInterval/loopDuration/cacheHours config"
+```
+
+---
+
+### Task 10: Persist frames to IndexedDB
+
+**Files:**
+- Modify: `web/cockpit/fisb-nexrad.js` (IDB open, write-on-snapshot, purge)
+
+- [ ] **Step 1: Add an IDB helper (own DB `flytab_radar`)**
+
+Add methods to `FisbNexrad`:
+
+```js
+    _openDb() {
+        if (this._dbPromise) return this._dbPromise;
+        this._dbPromise = new Promise((resolve, reject) => {
+            const req = indexedDB.open('flytab_radar', 1);
+            req.onupgradeneeded = (e) => {
+                const db = e.target.result;
+                if (!db.objectStoreNames.contains('nexradFrames'))
+                    db.createObjectStore('nexradFrames', { keyPath: 'dataTime' });
+            };
+            req.onsuccess = () => resolve(req.result);
+            req.onerror = () => reject(req.error);
+        });
+        return this._dbPromise;
+    }
+
+    async _persistFrame(snap) {
+        try {
+            const db = await this._openDb();
+            const blocks = [];
+            for (const [, b] of snap.blocks) blocks.push({ ...b, intensity: Array.from(b.intensity) });
+            const rec = { dataTime: snap.dataTime, time: snap.time, blocks };
+            const tx = db.transaction('nexradFrames', 'readwrite');
+            tx.objectStore('nexradFrames').put(rec);
+            await new Promise((res, rej) => { tx.oncomplete = res; tx.onerror = () => rej(tx.error); });
+            await this._purgeDb();
+        } catch (err) {
+            if (typeof DiagLog !== 'undefined') DiagLog.log('error', `radar persist failed: ${err.message}`);
+        }
+    }
+
+    async _purgeDb() {
+        const db = await this._openDb();
+        const cutoff = Date.now() - this._cacheHours * 3600000;
+        const tx = db.transaction('nexradFrames', 'readwrite');
+        const store = tx.objectStore('nexradFrames');
+        store.openCursor().onsuccess = (e) => {
+            const cur = e.target.result;
+            if (!cur) return;
+            if ((cur.value.time || 0) < cutoff) cur.delete();
+            cur.continue();
+        };
+    }
+```
+
+- [ ] **Step 2: Call `_persistFrame` from `_takeSnapshot`**
+
+At the end of `_takeSnapshot(time, dataTime)`, after pushing to `_frameHistory`:
+
+```js
+        this._persistFrame(this._frameHistory[this._frameHistory.length - 1]);
+```
+
+- [ ] **Step 3: Build + verify persistence via CDP**
+
+`bash build.sh`; run mock (set `frameIntervalMinutes:1` to accumulate); after a few minutes inspect IDB:
+Run (CDP): evaluate `indexedDB.databases()` then read `flytab_radar` → `nexradFrames` count.
+Expected: records present with `dataTime`, `blocks[]` (intensity as arrays, `radarType`/`scale` preserved).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/cockpit/fisb-nexrad.js
+git commit -m "feat(radar): persist NEXRAD frames to IndexedDB (cacheHours retention)"
+```
+
+---
+
+### Task 11: Hydrate frame history on startup
+
+**Files:**
+- Modify: `web/cockpit/fisb-nexrad.js` (constructor calls `_hydrate`)
+
+- [ ] **Step 1: Load persisted frames into `_frameHistory`**
+
+```js
+    async _hydrate() {
+        try {
+            const db = await this._openDb();
+            const cutoff = Date.now() - this._cacheHours * 3600000;
+            const tx = db.transaction('nexradFrames', 'readonly');
+            const recs = await new Promise((res, rej) => {
+                const r = tx.objectStore('nexradFrames').getAll();
+                r.onsuccess = () => res(r.result || []); r.onerror = () => rej(r.error);
+            });
+            const fresh = recs.filter(r => (r.time || 0) >= cutoff)
+                              .sort((a, b) => a.dataTime - b.dataTime)
+                              .slice(-this._maxFrames);
+            for (const r of fresh) {
+                const m = new Map();
+                for (const b of r.blocks) m.set(`${b.latN},${b.lonW}`, b);
+                this._frameHistory.push({ time: r.time, dataTime: r.dataTime, blocks: m });
+            }
+            // Seed live blocks + per-product age from the newest frame
+            const last = fresh[fresh.length - 1];
+            if (last) {
+                for (const b of last.blocks) {
+                    this._blocks.set(`${b.latN},${b.lonW}`, b);
+                    const p = FisbNexrad._productOf(b);
+                    this._newestAt[p] = Math.max(this._newestAt[p], last.time);
+                }
+            }
+        } catch (err) {
+            if (typeof DiagLog !== 'undefined') DiagLog.log('error', `radar hydrate failed: ${err.message}`);
+        }
+    }
+```
+
+Call `this._hydrate();` at the end of the constructor.
+
+- [ ] **Step 2: Build + verify resume-after-restart**
+
+`bash build.sh`; run mock to accumulate frames; force-stop FlyTab; reopen.
+Expected: enabling the radar/loop shows prior frames immediately (no waiting to re-accumulate); main map Regional, page CONUS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web/cockpit/fisb-nexrad.js
+git commit -m "feat(radar): hydrate frame history from IDB on startup"
+```
+
+---
+
+### Task 12: Export frames to NDJSON
+
+**Files:**
+- Modify: `web/cockpit/fisb-nexrad.js` (`exportFrames`)
+- Modify: `web/cockpit/radar-page.js` (Export button)
+
+- [ ] **Step 1: `exportFrames()` writes NDJSON via the on-device file server**
+
+```js
+    /** Export cached frames as NDJSON to the on-device server (next to flight CSVs). */
+    async exportFrames() {
+        const lines = this._frameHistory.map(snap => {
+            const NEXRAD = [];
+            for (const [, b] of snap.blocks) NEXRAD.push({
+                Radar_Type: b.radarType, Scale: b.scale,
+                LatNorth: b.latN, LonWest: b.lonW, Height: b.height, Width: b.width,
+                Intensity: Array.from(b.intensity),
+            });
+            return JSON.stringify({ Product_id: 63, NEXRAD,
+                LocaltimeReceived: new Date(snap.dataTime).toISOString() });
+        });
+        const iso = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+        const path = `flights/nexrad-${iso}.ndjson`;
+        const resp = await fetch(`http://localhost:9090/${path}`,
+            { method: 'PUT', body: lines.join('\n') });
+        if (typeof DiagLog !== 'undefined')
+            DiagLog.log('radar', `exportFrames → ${path} (${lines.length} frames, ok=${resp.ok})`);
+        return path;
+    }
+```
+
+- [ ] **Step 2: Add an Export control to the radar page header**
+
+In `radar-page.js` `_buildDom()` add a button before close:
+
+```html
+                <button class="radar-page-export">Export</button>
+```
+
+Wire it:
+
+```js
+        this._el.querySelector('.radar-page-export')
+            .addEventListener('click', () => this._fisb.exportFrames());
+```
+
+Style `.radar-page-export` like `.radar-page-close` (token-based; reuse class or add a rule).
+
+- [ ] **Step 3: Build + verify export file**
+
+`bash build.sh`; accumulate frames; open page → Export.
+Run: `~/Android/Sdk/platform-tools/adb shell run-as app.flywhere.flytab ls -la files` (or pull via the on-device server) to confirm `nexrad-<iso>.ndjson` exists; inspect a line — must have `Radar_Type`, `Scale`, `LatNorth`, `LonWest`, `Height`, `Width`, `Intensity`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/cockpit/fisb-nexrad.js web/cockpit/radar-page.js web/style.css
+git commit -m "feat(radar): export cached NEXRAD frames to NDJSON"
+```
+
+---
+
+### Task 13: `mock-stratux.py --replay-nexrad`
+
+**Files:**
+- Modify: `tools/mock-stratux.py`
+
+- [ ] **Step 1: Add the arg + replay loop**
+
+```python
+parser.add_argument('--replay-nexrad', help='Path to nexrad NDJSON to replay on /jsonio')
+```
+
+When set, instead of synthetic generation, read the file once into a list and, each tick, send the next line's JSON (loop at EOF), pacing by the configured tick interval:
+
+```python
+    if args.replay_nexrad:
+        with open(args.replay_nexrad) as f:
+            frames = [json.loads(l) for l in f if l.strip()]
+        # in the send loop:
+        await ws.send(json.dumps(frames[tick % len(frames)]))
+```
+
+- [ ] **Step 2: Verify with an exported file**
+
+Run: `python3 tools/mock-stratux.py --replay-nexrad tools/nexrad-<iso>.ndjson` (copy an export to `tools/`).
+Expected: the app renders the replayed Regional on the map and CONUS on the page, matching the captured flight.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tools/mock-stratux.py
+git commit -m "test(radar): mock-stratux --replay-nexrad for ground replay of captures"
+```
+
+---
+
+## Final verification (whole feature)
+
+- [ ] Main map: Regional only, correctly scaled, no oversized squares; `Regional · <age>` badge; loop animates.
+- [ ] MORE → Radar: CONUS page at SE-wide zoom; ownship centered; pan/zoom; Recenter; `CONUS · <age>` badge; loop animates; Export writes NDJSON.
+- [ ] Restart app → both loops resume from IDB; frames > `cacheHours` purged.
+- [ ] **Tap Handler Regression:** airport popup still opens on a normal tap on the main map.
+- [ ] Internet/ground radar unchanged (verify on the ground with internet tiles).
+- [ ] `node tools/test-productof.mjs` passes.
+- [ ] `FLYTAB_VERSION` bumped; `bash build.sh` clean.
+
+## Self-review notes (gaps to confirm during execution)
+
+- **`fisb:nexrad` event source:** Task 6 assumes `FisbNexrad` re-emits `fisb:nexrad`. Verify — it currently listens to the *FisbClient's* `fisb:nexrad`. If `FisbNexrad` is not an `EventTarget`, subscribe the page to `this._fisb._fisb` (the FisbClient) instead; the `.addEventListener?.` guard degrades safely but confirm the live redraw fires.
+- **`RadarLoop` show/hide API:** Task 7 references `_controlEl`, `show(map)`, `stop()`. Read `radar-loop.js` and match exact method names before wiring.
+- **On-device file server PUT:** Task 12 assumes the NanoHTTPD server at `localhost:9090` accepts `PUT` to `flights/`. Confirm against how `FlightRecorder._flush` writes (it uses the same base); match its method/headers.

--- a/docs/superpowers/specs/2026-05-29-fisb-nexrad-conus-radar-page-design.md
+++ b/docs/superpowers/specs/2026-05-29-fisb-nexrad-conus-radar-page-design.md
@@ -1,0 +1,264 @@
+# FIS-B NEXRAD: Regional/CONUS split + CONUS radar page
+
+**Date:** 2026-05-29
+**Status:** Design — pending review
+**Author:** Claude (with Dana)
+
+## Problem
+
+FIS-B NEXRAD started being received on the tablet for the first time (v9.26). On the
+moving map, some radar squares paint correctly while others are "much too large,"
+obscuring the good detail.
+
+### Root cause (confirmed from Stratux `uatparse/nexrad.go`)
+
+FIS-B broadcasts NEXRAD as two products, distinguished by `Product_id` and a `Scale`
+factor that **scales the block's geographic size**:
+
+| Product | `Radar_Type` | `Scale` → realScale | Block size | Bin grid |
+|---|---|---|---|---|
+| **Regional** (high-res) | 63 | 0 → ×1 | 0.8° × 0.067° | 32 (lon) × 4 (lat) = 128 bins |
+| **CONUS** (low-res) | 64 | 1 → ×5, 2 → ×9 | up to 7.2° × 0.6° | same 128-bin grid → bins 5–9× larger |
+
+The per-bin geometry math in `fisb-nexrad.js` is already correct. The defect is that
+**the renderer draws both products identically** and **discards `Radar_Type`/`Scale`**
+(`_handleNexrad`, fisb-nexrad.js:174–181 keeps only `latN, lonW, height, width,
+intensity, received_at`). CONUS blocks are 5–9× larger and presence-only CONUS blocks
+are filled with a uniform intensity `1` (solid light-green), so a single block paints a
+~200+ nm solid rectangle over the crisp Regional data. That is the "too large" symptom.
+
+## Goals
+
+1. **Map shows Regional only**, correctly scaled at any navigation zoom — the giant
+   CONUS squares never appear on the map.
+2. **CONUS gets its own home**: a dedicated, zoomed-out radar page ("show me all of the
+   Southeast") with the ownship icon for context.
+3. **Looping in both modes** — animation is the only way to gauge storm movement, so it
+   is required on the Regional map *and* the CONUS page, not optional.
+4. **A product + age badge** on each view so the pilot always knows which product and how
+   old it is (the ForeFlight habit).
+5. **Persist the frame cache** (`radar.cacheHours`) so the loop survives an app restart and
+   can be **exported** as a real fixture for ground testing — implementing config that was
+   provisioned but never wired up.
+
+## Non-goals
+
+- **Do not touch the internet/ground radar path.** `_sampleInternetTiles`,
+  `_sampleProduct`, `_rgbToNexradIntensity`, and the IEM tile sources stay exactly as-is.
+  Internet NEXRAD on the ground is verified working and must not regress.
+- **No base-tile snapshotting.** The live Leaflet map composites base chart tiles + radar
+  overlay and provides pan/zoom natively; a static PNG base would break the pannable
+  requirement and adds a CORS-taint hazard. (Rasterizing *radar frames* to images for
+  loop performance is a deferred optimization, only if tablet redraw proves too heavy.)
+- **No new tab-bar button.** Entry point is the MORE drawer.
+
+## Design
+
+### 1. Data model — tag every block with its product
+
+`FisbNexrad._handleNexrad` keeps two more fields per stored block:
+
+```
+block = { latN, lonW, height, width, intensity, received_at,
+          radarType,   // = msg.NEXRAD[i].Radar_Type  (63 Regional | 64 CONUS)
+          scale }      // = msg.NEXRAD[i].Scale        (0 | 1 | 2)
+```
+
+Pure classifier (extractable for unit test):
+
+```
+FisbNexrad._productOf(block) → 'conus' | 'regional'
+  return (block.radarType === 64 || block.scale > 0) ? 'conus' : 'regional'
+```
+
+Frame-history snapshots already clone the whole block set every 2.5 min (24-frame /
+~60-min ring), so each frame now carries both products automatically — both loops read
+the same history.
+
+Per-product freshness for the badge:
+```
+this._newestAt = { regional: 0, conus: 0 }   // updated in _handleNexrad per block product
+getDataAgeMs(product) → this._newestAt[product] ? Date.now() - this._newestAt[product] : null
+```
+
+### 2. Renderer: one data layer, product-aware render to a target
+
+`FisbNexrad` remains the single data owner (block store + frame history). Rendering is
+parameterized by a **target** and a **product filter** so the same blocks can paint to
+the main map (Regional) or the CONUS page (CONUS) without duplicating data or event
+listeners.
+
+```
+// target = { map, canvas, ctx }   product = 'regional' | 'conus'
+FisbNexrad.draw(target, product)                  // live current blocks
+FisbNexrad.drawFrame(target, product, frameIndex)  // a history frame (for the loop)
+```
+
+- Internal refactor: current `_draw()` / `drawFrame(i)` bodies move into
+  `_drawToTarget(target, product, blockMap, zoom)`, which iterates `blockMap`, skips
+  blocks where `_productOf(block) !== product`, runs the existing viewport-bounds cull,
+  and calls the **unchanged** `_drawBlock(ctx, map, block, zoom)`.
+- Main map keeps its existing canvas in `overlayPane`; `FisbNexrad` stores it as
+  `this._mainTarget = { map, canvas, ctx }`. The existing `move/zoom/resize` handlers call
+  `this.draw(this._mainTarget, 'regional')`.
+- `addTo(map)` / `remove()` semantics for the main target are unchanged.
+
+### 3. Main map — Regional only + loop + badge
+
+- Renders **Regional only**. CONUS blocks are filtered out → no oversized squares, and the
+  remaining Regional detail is correctly scaled at every nav zoom.
+- The existing `RadarLoop` continues to drive the main map, now with `product='regional'`.
+- Badge (small, light-theme): `FIS-B · Regional · <age>` using `getDataAgeMs('regional')`.
+  Reuses the map's existing badge/overlay styling conventions.
+
+### 4. `RadarPage` — dedicated CONUS view (new file `web/cockpit/radar-page.js`)
+
+Full-screen page following the existing page pattern (`engine-page`, `approach-charts`).
+
+- **Own Leaflet map** (`this._map`) on its own container — never touches the nav map, the
+  route editor, or the three map tap handlers. (Honors the Tap Handler Regression Rule:
+  the main-map handlers are not modified.)
+- Base layer: the same chart tile source the main map uses (chart tiles exist to zoom 4).
+- **Default view (option C):** on `show()`, center on ownship at a fixed Southeast-wide
+  zoom (~zoom 5–6, tunable via `cockpit-config` `radar.conusDefaultZoom`). **Pannable and
+  pinch-zoomable.** A **"Recenter on me"** button restores center=ownship, zoom=default.
+- **Ownship icon** marker, updated from `GpsSource` while the page is visible (reuse the
+  app's existing ownship icon asset/rotation if available; otherwise a simple aircraft
+  divIcon).
+- Renders **CONUS only**: a canvas overlay in its map's `overlayPane`; the page calls
+  `fisbNexrad.draw(this._target, 'conus')` on map move/zoom and on new data.
+- **Own loop control** (see §5), reading the shared CONUS frames.
+- Badge: `FIS-B · CONUS · <age>` using `getDataAgeMs('conus')`.
+- Empty state: if no CONUS frames, show "NO FIS-B CONUS RADAR" (mirrors `RadarLoop`'s
+  existing no-data message).
+
+**Lifecycle:**
+- `_map` and canvas are **lazily created on first `show()`** and retained (creating/
+  destroying a Leaflet map per open is wasteful).
+- While visible: subscribe to `fisb:nexrad` redraws and a position tick for the ownship
+  marker. On `hide()`: stop the loop, unsubscribe the position tick, leave `_map` intact
+  for reuse.
+- `isVisible()` returns whether the page is shown.
+
+### 5. Loop — target-aware `RadarLoop`
+
+Make `RadarLoop` construct against a `{ renderer, target, product }` so playback logic is
+written once and reused:
+
+- **Main-map loop:** existing instance, `target=mainTarget`, `product='regional'`.
+- **CONUS-page loop:** new instance owned by `RadarPage`, `target=pageTarget`,
+  `product='conus'`.
+
+Both iterate `renderer.frameHistory` and call `renderer.drawFrame(target, product, i)`.
+`enterLoopMode`/`exitLoopMode` suppression of live draws applies per target. The CONUS
+loop is FIS-B-only (no internet fallback on this page).
+
+### 6. MORE drawer entry
+
+Add to the **In-flight** section of `tab-bar.js` `_buildMoreDrawer()` (after Approach
+Charts), matching the existing item shape:
+
+```
+{ icon: '🌧', label: 'Radar', action: () => {
+    c.radarPage?.show();
+    this._hideRadarControls();
+    this._closeMoreDrawer();
+}}
+```
+
+`RadarPage` is instantiated in `app.js` and passed into `TabBar` components as
+`c.radarPage`, wired with the shared `FisbNexrad` instance and `GpsSource`.
+
+### 7. Frame persistence & export (`radar.cacheHours`)
+
+Implement the provisioned-but-dead config so the frame ring survives an app restart and
+can be replayed on the ground.
+
+**Wire the existing config into `FisbNexrad`** (currently hardcodes a 24-frame / 2.5-min
+ring and ignores all three knobs):
+- `radar.frameIntervalMinutes` → snapshot cadence (replaces the hardcoded 150 000 ms).
+- `radar.loopDurationHours` → `_maxFrames = loopDurationHours * 60 / frameIntervalMinutes`.
+- `radar.cacheHours` → persistence retention window.
+
+**Persistence (IndexedDB):**
+- New object store `nexradFrames` in the app's existing IDB. One record per snapshot:
+  `{ dataTime (keyPath), time, blocks: [{ latN, lonW, height, width, intensity[],
+  radarType, scale }] }`.
+- The data layer writes one record each time it takes a snapshot (the `frameIntervalMinutes`
+  cadence), **not** per-draw. Writes are small (hundreds of blocks) — no NASR-style bulk-
+  transaction hang risk (see CLAUDE.md IDB caveat, which applies only to huge single txns).
+- **Purge** records older than `cacheHours` on write and on the existing 30 s purge timer.
+- **Hydrate on startup:** `FisbNexrad` loads `nexradFrames` within `cacheHours` into
+  `_frameHistory` (and seeds `_blocks` from the newest frame) so both the Regional map loop
+  and the CONUS page loop resume immediately after the app reopens. This is what prevents a
+  repeat of "today's frames are gone."
+
+**Export (ground fixture):**
+- `FisbNexrad.exportFrames()` serializes cached frames to **NDJSON** (one frame per line,
+  blocks emitted in the **exact Stratux `NEXRAD[]` shape**: `Radar_Type, Scale, LatNorth,
+  LonWest, Height, Width, Intensity`) so the file is a faithful capture, not a lossy re-shape.
+- Written to the home-server flights path via the existing `FlightRecorder` fetch pattern
+  (`LOCAL_BASE`), filename `nexrad-<ISO>.ndjson`, landing next to the engine CSV and pullable.
+- **Trigger: manual only** — a small "Export radar frames" control (radar page or config
+  editor). Never automatic.
+- `mock-stratux.py` gains `--replay-nexrad <file.ndjson>`: re-emits those frames on `/jsonio`
+  with original inter-frame timing (optionally time-scaled), replaying the full pipeline on
+  the ground.
+
+This closes the test loop: build against the synthetic emitter now → next FIS-B flight
+**auto-caches real frames (persisted)** → export NDJSON → replay through `mock-stratux.py`
+→ validate the synthetic geometry and the CONUS page against real data.
+
+## Interface contracts (summary)
+
+| Boundary | Contract |
+|---|---|
+| Stratux → `FisbNexrad` | `msg.NEXRAD[i]`: `Radar_Type` (int), `Scale` (int), `LatNorth`, `LonWest`, `Height`, `Width`, `Intensity[]` |
+| stored block | adds `radarType` (number), `scale` (number); `_productOf(block)` → `'conus'\|'regional'` |
+| `FisbNexrad.draw(target, product)` | `target={map,canvas,ctx}`, `product∈{'regional','conus'}` |
+| `FisbNexrad.drawFrame(target, product, i)` | `i` indexes `frameHistory` |
+| `FisbNexrad.getDataAgeMs(product)` | ms since newest block of that product, or null |
+| `RadarPage(fisbNexrad, gpsSource)` | `.show()`, `.hide()`, `.isVisible()` |
+| `RadarLoop({renderer, target, product})` | playback over `renderer.frameHistory` |
+| TabBar components | `c.radarPage` present |
+| IDB store `nexradFrames` | keyPath `dataTime`; value `{time, dataTime, blocks[]}` |
+| `FisbNexrad` config reads | `radar.cacheHours`, `radar.loopDurationHours`, `radar.frameIntervalMinutes` |
+| `FisbNexrad.exportFrames()` | writes `nexrad-<ISO>.ndjson` via `LOCAL_BASE`; returns path |
+| `mock-stratux.py --replay-nexrad <file>` | re-emits NDJSON frames on `/jsonio` |
+
+## Testing
+
+- **Pure unit test** (extractable): `_productOf` classification — 63/scale0 → regional;
+  64 → conus; scale 1/2 → conus. (Not in `web/shared/planning/`, so a small standalone
+  assertion or manual verification; no vitest harness covers cockpit JS.)
+- **Manual on tablet (required):**
+  - Map: only Regional paints; no oversized squares; badge shows `Regional · <age>`.
+  - Map loop animates Regional history.
+  - MORE → Radar opens the CONUS page; ownship centered at SE-wide zoom; pan/zoom works;
+    Recenter returns to ownship/default; CONUS blocks paint; badge shows `CONUS · <age>`;
+    loop animates.
+  - **Tap Handler Regression Rule:** after this work, confirm tapping an airport on the
+    **main** map still opens its popup (the main-map handlers must be untouched).
+  - Internet/ground radar on the ground still works unchanged.
+- **Persistence:** record frames, force-stop and reopen the app, confirm both loops resume
+  with the prior frames; confirm frames older than `cacheHours` are purged; confirm
+  `frameIntervalMinutes`/`loopDurationHours` changes affect cadence and ring length.
+- **Export + replay:** trigger Export, confirm `nexrad-<ISO>.ndjson` on the home server with
+  the correct Stratux field shape; `mock-stratux.py --replay-nexrad` it and confirm the
+  Regional map and CONUS page render identically to the live flight.
+
+## Risks / open items
+
+- **Second Leaflet instance on the tablet** — watch redraw cost; the radar-frame→PNG
+  rasterization (deferred) is the mitigation if the CONUS loop is heavy.
+- **Light theme only** — the radar page must not set `data-mode="cockpit"`.
+- **Default CONUS zoom** (~5–6) is a starting value; tune on-device for a Southeast-wide
+  framing.
+- **Ownship asset reuse** — confirm whether the main map exposes a reusable ownship
+  icon/rotation helper, else use a simple aircraft divIcon on the page.
+- **IDB frame writes** — keep cadence low (per snapshot) and serialize `Intensity` compactly;
+  small per-write payloads avoid the long-transaction hang documented in CLAUDE.md (which is
+  specific to the 18 MB NASR import, not these writes).
+- **Scope** — this feature now spans the Regional/CONUS render split, the CONUS page, the two
+  loops, **and** frame persistence/export. Still one coherent feature; the implementation plan
+  should phase it (render split + badge first, then CONUS page + loop, then persistence/export).

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -155,6 +155,7 @@ Opens a right-side drawer with infrequently used actions, organized in three sec
 | **Fuel Entry** | Manually enter fuel quantity after a fuel stop |
 | **Weight & Balance** | Enter station weights and fuel; shows total weight, CG, and envelope status with a CG diagram |
 | **Approach Charts** | Georeferenced approach plates overlaid on the map |
+| **Radar (CONUS)** | Full-screen CONUS NEXRAD view centered on ownship. Tap **Recenter on me** to return to ownship position after panning. A badge shows the data source and age (e.g. *FIS-B · CONUS · 4 min*). Use the play/scrub loop at the bottom to animate up to ~55 minutes of history and gauge storm movement. The main map shows the higher-resolution Regional product; this page shows the full CONUS mosaic for situational awareness at a wider scale. |
 | **Engine ML** | Opens the real-time ML anomaly monitor |
 | **Stratux Status** | Opens the Stratux web interface in a browser |
 

--- a/tools/mock-stratux.py
+++ b/tools/mock-stratux.py
@@ -62,6 +62,10 @@ for t in _traffic:
 
 _start_time = time.time()
 
+# Path to a NEXRAD NDJSON capture to replay on /jsonio (set in __main__).
+_REPLAY_PATH  = None
+_replay_frames = None   # loaded lazily on first use in _jsonio_loop()
+
 # --- Synthetic FIS-B NEXRAD ---------------------------------------------
 BLOCK_H = 4.0 / 60.0          # 0.0667 deg lat  (matches Stratux BLOCK_HEIGHT)
 BLOCK_W = 48.0 / 60.0         # 0.8 deg lon      (matches Stratux BLOCK_WIDTH)
@@ -213,11 +217,29 @@ async def _situation_loop():
 
 
 async def _jsonio_loop():
-    """Emit a synthetic NEXRAD frame to /jsonio clients every 5 seconds."""
+    """Emit NEXRAD frames to /jsonio clients every 5 seconds.
+
+    If --replay-nexrad was given, replay the captured NDJSON frames (looping at
+    EOF); otherwise emit synthetic frames from _nexrad_frame(tick).
+    """
+    global _replay_frames
+    # Load the replay file once, if configured.
+    if _REPLAY_PATH and _replay_frames is None:
+        try:
+            with open(_REPLAY_PATH) as f:
+                _replay_frames = [json.loads(l) for l in f if l.strip()]
+            print(f"  [replay] loaded {len(_replay_frames)} NEXRAD frames from {_REPLAY_PATH}")
+        except Exception as e:
+            print(f"  [replay] failed to load {_REPLAY_PATH}: {e}; using synthetic")
+            _replay_frames = []
+
     tick = 0
     while True:
         if _jsonio_clients:
-            await _broadcast(_jsonio_clients, _nexrad_frame(tick))
+            if _replay_frames:
+                await _broadcast(_jsonio_clients, _replay_frames[tick % len(_replay_frames)])
+            else:
+                await _broadcast(_jsonio_clients, _nexrad_frame(tick))
         tick += 1
         await asyncio.sleep(5.0)
 
@@ -255,10 +277,12 @@ async def handler(websocket):
 
     elif path == "/jsonio":
         _jsonio_clients.add(websocket)
+        print(f"  [+] jsonio client   ({len(_jsonio_clients)} connected)")
         try:
             await websocket.wait_closed()
         finally:
             _jsonio_clients.discard(websocket)
+            print(f"  [-] jsonio client   ({len(_jsonio_clients)} connected)")
 
     else:
         await websocket.close(1008, f"unknown path: {path}")
@@ -289,10 +313,12 @@ if __name__ == "__main__":
     parser.add_argument("--port", type=int, default=5678, help="Port (default: 5678)")
     parser.add_argument("--lat",  type=float, default=OWN_LAT)
     parser.add_argument("--lon",  type=float, default=OWN_LON)
+    parser.add_argument("--replay-nexrad", help="Path to a NEXRAD NDJSON capture to replay on /jsonio (loops at EOF)")
     args = parser.parse_args()
 
     OWN_LAT = args.lat
     OWN_LON = args.lon
+    _REPLAY_PATH = args.replay_nexrad
 
     try:
         asyncio.run(main(args.host, args.port))

--- a/tools/mock-stratux.py
+++ b/tools/mock-stratux.py
@@ -62,6 +62,53 @@ for t in _traffic:
 
 _start_time = time.time()
 
+# --- Synthetic FIS-B NEXRAD ---------------------------------------------
+BLOCK_H = 4.0 / 60.0          # 0.0667 deg lat  (matches Stratux BLOCK_HEIGHT)
+BLOCK_W = 48.0 / 60.0         # 0.8 deg lon      (matches Stratux BLOCK_WIDTH)
+
+
+def _nexrad_block(lat_n, lon_w, scale, intensities):
+    """One NEXRADBlock in Stratux /jsonio shape."""
+    real = {0: 1.0, 1: 5.0, 2: 9.0}[scale]
+    return {
+        "Radar_Type": 63 if scale == 0 else 64,
+        "Scale":      scale,
+        "LatNorth":   round(lat_n, 4),
+        "LonWest":    round(lon_w, 4),
+        "Height":     round(BLOCK_H * real, 4),
+        "Width":      round(BLOCK_W * real, 4),
+        "Intensity":  intensities,      # list[int] length 128 (32 cols × 4 rows)
+    }
+
+
+def _gradient_cell(seed):
+    """128-bin (32×4) intensity grid: a moving blob of levels 1–6."""
+    out = []
+    for r in range(4):
+        for c in range(32):
+            d = abs(c - (seed % 32)) + abs(r - 2)
+            out.append(max(0, 6 - d) if d <= 6 else 0)
+    return out
+
+
+def _nexrad_frame(tick):
+    """Stratux UATFrame-shaped dict with Regional + CONUS blocks; cells drift east with tick."""
+    seed = tick % 32
+    regional = [
+        _nexrad_block(OWN_LAT + 0.50, OWN_LON - 0.4 + 0.05 * seed, 0, _gradient_cell(seed)),
+        _nexrad_block(OWN_LAT + 0.43, OWN_LON - 0.4 + 0.05 * seed, 0, _gradient_cell(seed + 4)),
+    ]
+    conus = []
+    for i in range(3):
+        conus.append(_nexrad_block(35.0 + 0.33 * i, -84.0 + 4.0 + 0.2 * seed, 1,
+                                   _gradient_cell(seed + i * 3)))
+    return {
+        "Product_id":        63,
+        "NEXRAD":            regional + conus,
+        "LocaltimeReceived": time.strftime("%Y-%m-%dT%H:%M:%S"),
+    }
+
+
 # Connected client sets for each endpoint
 _traffic_clients   = set()
 _situation_clients = set()
@@ -165,6 +212,16 @@ async def _situation_loop():
         await asyncio.sleep(1.0)
 
 
+async def _jsonio_loop():
+    """Emit a synthetic NEXRAD frame to /jsonio clients every 5 seconds."""
+    tick = 0
+    while True:
+        if _jsonio_clients:
+            await _broadcast(_jsonio_clients, _nexrad_frame(tick))
+        tick += 1
+        await asyncio.sleep(5.0)
+
+
 async def handler(websocket):
     try:
         path = websocket.request.path
@@ -222,6 +279,7 @@ async def main(host, port):
         await asyncio.gather(
             _traffic_loop(),
             _situation_loop(),
+            _jsonio_loop(),
         )
 
 

--- a/tools/test-productof.mjs
+++ b/tools/test-productof.mjs
@@ -1,0 +1,9 @@
+import assert from 'node:assert';
+// Mirror of FisbNexrad._productOf (kept in sync; pure function).
+const productOf = (b) => (b.radarType === 64 || b.scale > 0) ? 'conus' : 'regional';
+
+assert.equal(productOf({ radarType: 63, scale: 0 }), 'regional');
+assert.equal(productOf({ radarType: 64, scale: 1 }), 'conus');
+assert.equal(productOf({ radarType: 63, scale: 1 }), 'conus'); // scale wins
+assert.equal(productOf({ radarType: 64, scale: 0 }), 'conus'); // type wins
+console.log('OK productOf');

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,7 @@
  * Android Capacitor cockpit app. All data local. Pi for live telemetry only.
  */
 
-const FLYTAB_VERSION = 'v9.31';
+const FLYTAB_VERSION = 'v9.32';
 
 // === Diagnostic Logger (ring buffer in localStorage) ==========
 const DiagLog = (() => {

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,7 @@
  * Android Capacitor cockpit app. All data local. Pi for live telemetry only.
  */
 
-const FLYTAB_VERSION = 'v9.34';
+const FLYTAB_VERSION = 'v9.38';
 
 // === Diagnostic Logger (ring buffer in localStorage) ==========
 const DiagLog = (() => {

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,7 @@
  * Android Capacitor cockpit app. All data local. Pi for live telemetry only.
  */
 
-const FLYTAB_VERSION = 'v9.29';
+const FLYTAB_VERSION = 'v9.30';
 
 // === Diagnostic Logger (ring buffer in localStorage) ==========
 const DiagLog = (() => {

--- a/web/app.js
+++ b/web/app.js
@@ -54,6 +54,7 @@ class FlyTabApp {
         this.engineGpsBridge = null;
         this._gpsDiagPanel = null;
         this.cockpitMap = null;
+        this.radarPage = null;
         this.enginePanel = null;
         this.trackLog = null;
         this.deviceStatus = null;
@@ -691,6 +692,11 @@ class FlyTabApp {
         if (typeof FisbNexrad !== 'undefined' && this.fisbClient) {
             this.fisbNexrad = new FisbNexrad(this.fisbClient);
             this.cockpitMap.setFisbNexrad(this.fisbNexrad);
+
+            // Dedicated full-screen CONUS radar page (own map). Drawer entry wired in a later task.
+            if (typeof RadarPage !== 'undefined') {
+                this.radarPage = new RadarPage(this.fisbNexrad, this.stratuxClient);
+            }
         }
 
         // Convective Intelligence Engine — must be after fisbClient and fisbNexrad are assigned

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,7 @@
  * Android Capacitor cockpit app. All data local. Pi for live telemetry only.
  */
 
-const FLYTAB_VERSION = 'v9.27';
+const FLYTAB_VERSION = 'v9.28';
 
 // === Diagnostic Logger (ring buffer in localStorage) ==========
 const DiagLog = (() => {

--- a/web/app.js
+++ b/web/app.js
@@ -919,6 +919,7 @@ class FlyTabApp {
                 stratuxIp: Settings.stratuxIp || '192.168.10.1',
                 planSync: this.planSync,
                 radarLoop: this.radarLoop,
+                radarPage: this.radarPage,
                 flightUpload: this.flightUpload,
                 routeTable: this.routeTable,
                 layerPanel: this.layerPanel,

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,7 @@
  * Android Capacitor cockpit app. All data local. Pi for live telemetry only.
  */
 
-const FLYTAB_VERSION = 'v9.32';
+const FLYTAB_VERSION = 'v9.33';
 
 // === Diagnostic Logger (ring buffer in localStorage) ==========
 const DiagLog = (() => {

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,7 @@
  * Android Capacitor cockpit app. All data local. Pi for live telemetry only.
  */
 
-const FLYTAB_VERSION = 'v9.30';
+const FLYTAB_VERSION = 'v9.31';
 
 // === Diagnostic Logger (ring buffer in localStorage) ==========
 const DiagLog = (() => {

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,7 @@
  * Android Capacitor cockpit app. All data local. Pi for live telemetry only.
  */
 
-const FLYTAB_VERSION = 'v9.28';
+const FLYTAB_VERSION = 'v9.29';
 
 // === Diagnostic Logger (ring buffer in localStorage) ==========
 const DiagLog = (() => {

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,7 @@
  * Android Capacitor cockpit app. All data local. Pi for live telemetry only.
  */
 
-const FLYTAB_VERSION = 'v9.26';
+const FLYTAB_VERSION = 'v9.27';
 
 // === Diagnostic Logger (ring buffer in localStorage) ==========
 const DiagLog = (() => {

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,7 @@
  * Android Capacitor cockpit app. All data local. Pi for live telemetry only.
  */
 
-const FLYTAB_VERSION = 'v9.38';
+const FLYTAB_VERSION = 'v9.39';
 
 // === Diagnostic Logger (ring buffer in localStorage) ==========
 const DiagLog = (() => {

--- a/web/app.js
+++ b/web/app.js
@@ -3,7 +3,7 @@
  * Android Capacitor cockpit app. All data local. Pi for live telemetry only.
  */
 
-const FLYTAB_VERSION = 'v9.33';
+const FLYTAB_VERSION = 'v9.34';
 
 // === Diagnostic Logger (ring buffer in localStorage) ==========
 const DiagLog = (() => {

--- a/web/cockpit-config.json
+++ b/web/cockpit-config.json
@@ -102,7 +102,8 @@
     "playbackSpeedMs": 500,
     "opacity": 0.5,
     "autoLoop": true,
-    "cacheHours": 3
+    "cacheHours": 3,
+    "conusDefaultZoom": 6
   },
   "approachCharts": {
     "georefEnabled": true,

--- a/web/cockpit/approach-charts.js
+++ b/web/cockpit/approach-charts.js
@@ -10,6 +10,8 @@
 const PLATES_BASE = 'http://localhost:9090/plates';
 const CIFP_BUNDLE_URL = 'http://localhost:9090/cifp/cifp_bundle.json';
 const PLATES_FETCH_TIMEOUT = 3000; // 3s timeout for NanoHTTPD requests
+// v2: pipeline corrected altitude field offset (col 84:89 not 83:88); stale caches show altitudes 10× too small
+const CIFP_BUNDLE_CACHE_KEY = 'cifp_bundle_v2';
 
 /** Fetch with a timeout (AbortController). Rejects on timeout. */
 function _fetchWithTimeout(url, opts = {}, timeoutMs = PLATES_FETCH_TIMEOUT) {
@@ -74,7 +76,7 @@ class ApproachCharts {
         // Try CIFP bundle from IndexedDB cache
         if (this._nasrDb) {
             try {
-                const cachedCifp = await this._nasrDb.getAppCache('cifp_bundle');
+                const cachedCifp = await this._nasrDb.getAppCache(CIFP_BUNDLE_CACHE_KEY);
                 if (cachedCifp) {
                     this._cifpBundle = cachedCifp;
                     console.log('[ApproachCharts] CIFP bundle from cache:', Object.keys(cachedCifp).length, 'airports');
@@ -128,7 +130,7 @@ class ApproachCharts {
                     const data = await resp.json();
                     this._cifpBundle = data;
                     console.log('[ApproachCharts] CIFP bundle loaded:', Object.keys(data).length, 'airports');
-                    if (this._nasrDb) this._nasrDb.putAppCache('cifp_bundle', data).catch(() => {});
+                    if (this._nasrDb) this._nasrDb.putAppCache(CIFP_BUNDLE_CACHE_KEY, data).catch(() => {});
                 }
             } catch (err) {
                 console.warn('[ApproachCharts] CIFP bundle not available:', err.message);
@@ -997,7 +999,7 @@ class ApproachCharts {
                     const resp = await _fetchWithTimeout(CIFP_BUNDLE_URL, {}, 30000);
                     if (resp.ok) {
                         this._cifpBundle = await resp.json();
-                        if (this._nasrDb) this._nasrDb.putAppCache('cifp_bundle', this._cifpBundle).catch(() => {});
+                        if (this._nasrDb) this._nasrDb.putAppCache(CIFP_BUNDLE_CACHE_KEY, this._cifpBundle).catch(() => {});
                     }
                 } catch { /* will fall through to error below */ }
             }

--- a/web/cockpit/config-editor.js
+++ b/web/cockpit/config-editor.js
@@ -69,6 +69,13 @@ class ConfigEditor {
 
         // Cockpit config sections
         sections.push(this._sectionHeader('Cockpit Configuration'));
+        // Simulation (top-level keys) — drives the mock-stratux bridge for ground testing.
+        // Takes effect on next app reload.
+        sections.push(this._renderSection('root', 'Simulation (reload to apply)', this._cockpitConfig || {}, {
+            'simMode': { type: 'bool', label: 'Sim Mode (mock bridge)' },
+            'simBridgeIp': { type: 'text', label: 'Sim Bridge IP', wide: true },
+            'simBridgePort': { type: 'number', label: 'Sim Bridge Port', min: 1, max: 65535 },
+        }));
         sections.push(this._renderSection('map', 'Map Settings', this._cockpitConfig.map || {}, {
             'defaultBaseLayer': { type: 'select', options: ['vector', 'sectional', 'osm'], label: 'Base Layer' },
             'defaultZoom': { type: 'number', label: 'Default Zoom', min: 4, max: 14 },
@@ -511,6 +518,11 @@ class ConfigEditor {
                     this._cockpitConfig[section][key] = val;
                 });
             }
+
+            // Collect top-level keys (Simulation section) — written to config root, not nested.
+            body.querySelectorAll('[data-section="root"]').forEach(el => {
+                this._cockpitConfig[el.dataset.key] = this._getInputValue(el);
+            });
 
             // Collect overlay fields (nested: overlays.fixes.minZoom)
             if (!this._cockpitConfig.map) this._cockpitConfig.map = {};

--- a/web/cockpit/engine-ml.js
+++ b/web/cockpit/engine-ml.js
@@ -782,6 +782,21 @@ class EngineMLBridge {
         // Runup→idle drops >300 RPM on the ground and the 60-sample ML window
         // flags the transition as anomalous once ThresholdAdapter tightens.
         if (physicsAlarm && result.anomaly === true && this._hasLaunched) {
+            // AGL lower-bound guard: below 500 ft AGL, throttle retard during the landing
+            // flare is indistinguishable from an engine failure by physics rules (same MAP
+            // and RPM drop). _hasLaunched stays true while groundSpeed > 30 kts so the
+            // existing ground guard doesn't catch the flare. Below 500 ft the pilot is
+            // committed to the runway ahead regardless — the emergency overlay adds no
+            // actionable value and a false squawk-7700 alert is dangerous noise.
+            const altMSL = this._altHistory.length > 0
+                ? this._altHistory[this._altHistory.length - 1]
+                : (sit?.alt_msl ?? 0);
+            const agl = this._fieldElev !== null ? (altMSL - this._fieldElev) : altMSL;
+            if (agl < 500) {
+                console.log(`[EngineML] Emergency suppressed — AGL ${Math.round(agl)} ft < 500 ft (landing flare guard)`);
+                return;
+            }
+
             console.warn('[EngineML] EMERGENCY: physics + ML joint confirmation — power loss');
             if (typeof EmergencyGlide !== 'undefined' && window.emergencyGlide) {
                 window.emergencyGlide.trigger({ engineRaw: d, sit, mlResult: result });

--- a/web/cockpit/fisb-nexrad.js
+++ b/web/cockpit/fisb-nexrad.js
@@ -12,7 +12,7 @@ class FisbNexrad {
         this._ctx = null;
         this._active = false;
 
-        // NEXRAD block store: "latN,lonW" → { latN, lonW, height, width, intensity[], radarType, scale, received_at }
+        // NEXRAD block store: "product,latN,lonW" → { latN, lonW, height, width, intensity[], radarType, scale, received_at }
         this._blocks = new Map();
 
         // Per-product freshness: tracks the most recent received_at for each product type
@@ -117,8 +117,12 @@ class FisbNexrad {
         // Redraw on any map movement (including during panning)
         map.on('move zoom moveend zoomend', this._onMove);
 
-        // If hydrated frames already exist from a prior session, switch the loop source to
-        // FIS-B now instead of waiting for the next live snapshot (up to frameIntervalMinutes).
+        // Re-hydrate frame history from IDB (cleared by remove() on the prior toggle).
+        // Fire-and-forget; after hydration completes _checkLoopReady() notifies the map.
+        if (this._frameHistory.length === 0) this._hydrate();
+
+        // If hydrated frames already exist (prior addTo that was never removed), switch the
+        // loop source to FIS-B now instead of waiting for the next live snapshot.
         if (!this._loopReadyFired && this._frameHistory.length >= 2) {
             this._loopReadyFired = true;
             window.app?.cockpitMap?.onFisbNexradLoopReady?.();
@@ -199,7 +203,6 @@ class FisbNexrad {
         for (const block of blocks) {
             if (!block.Intensity || block.Intensity.length === 0) continue;
 
-            const key = `${block.LatNorth},${block.LonWest}`;
             const stored = {
                 latN: block.LatNorth,
                 lonW: block.LonWest,
@@ -210,6 +213,10 @@ class FisbNexrad {
                 scale: block.Scale,             // 0 | 1 | 2
                 received_at: now,
             };
+            // Include product in key so Regional and CONUS blocks at the same lat/lon
+            // origin don't overwrite each other (CONUS grid is 5× coarser but shares
+            // some northwest-corner coordinates with the Regional grid).
+            const key = `${FisbNexrad._productOf(stored)},${block.LatNorth},${block.LonWest}`;
             this._blocks.set(key, stored);
             const p = FisbNexrad._productOf(stored);
             if (now > this._newestAt[p]) this._newestAt[p] = now;
@@ -324,7 +331,7 @@ class FisbNexrad {
                               .slice(-this._maxFrames);
             for (const r of fresh) {
                 const m = new Map();
-                for (const b of r.blocks) m.set(`${b.latN},${b.lonW}`, b);
+                for (const b of r.blocks) m.set(`${FisbNexrad._productOf(b)},${b.latN},${b.lonW}`, b);
                 this._frameHistory.push({ time: r.time, dataTime: r.dataTime, blocks: m });
             }
             // Keep newest-last ordering and the ring cap even if a live frame raced in.
@@ -338,10 +345,16 @@ class FisbNexrad {
             const last = this._frameHistory[this._frameHistory.length - 1];
             if (last) {
                 for (const [, b] of last.blocks) {
-                    this._blocks.set(`${b.latN},${b.lonW}`, b);
+                    this._blocks.set(`${FisbNexrad._productOf(b)},${b.latN},${b.lonW}`, b);
                     const p = FisbNexrad._productOf(b);
                     this._newestAt[p] = Math.max(this._newestAt[p], last.time);
                 }
+            }
+            // Notify the map to switch to FIS-B loop source if enough frames were loaded.
+            // Covers the toggle path (addTo re-calls _hydrate after remove() cleared history).
+            if (this._active && !this._loopReadyFired && this._frameHistory.length >= 2) {
+                this._loopReadyFired = true;
+                window.app?.cockpitMap?.onFisbNexradLoopReady?.();
             }
         } catch (err) {
             if (typeof DiagLog !== 'undefined') DiagLog.log('error', `radar hydrate failed: ${err.message}`);

--- a/web/cockpit/fisb-nexrad.js
+++ b/web/cockpit/fisb-nexrad.js
@@ -158,7 +158,11 @@ class FisbNexrad {
     /** Get current block count */
     get blockCount() { return this._blocks.size; }
 
-    getDataAgeMs() {
+    getDataAgeMs(product) {
+        if (product) {
+            const t = this._newestAt[product];
+            return t ? Date.now() - t : null;
+        }
         return this._latestDataTime ? Date.now() - this._latestDataTime : null;
     }
 

--- a/web/cockpit/fisb-nexrad.js
+++ b/web/cockpit/fisb-nexrad.js
@@ -244,6 +244,50 @@ class FisbNexrad {
         while (this._frameHistory.length > this._maxFrames) {
             this._frameHistory.shift();
         }
+        this._persistFrame(this._frameHistory[this._frameHistory.length - 1]);
+    }
+
+    _openDb() {
+        if (this._dbPromise) return this._dbPromise;
+        this._dbPromise = new Promise((resolve, reject) => {
+            const req = indexedDB.open('flytab_radar', 1);
+            req.onupgradeneeded = (e) => {
+                const db = e.target.result;
+                if (!db.objectStoreNames.contains('nexradFrames'))
+                    db.createObjectStore('nexradFrames', { keyPath: 'dataTime' });
+            };
+            req.onsuccess = () => resolve(req.result);
+            req.onerror = () => reject(req.error);
+        });
+        return this._dbPromise;
+    }
+
+    async _persistFrame(snap) {
+        try {
+            const db = await this._openDb();
+            const blocks = [];
+            for (const [, b] of snap.blocks) blocks.push({ ...b, intensity: Array.from(b.intensity) });
+            const rec = { dataTime: snap.dataTime, time: snap.time, blocks };
+            const tx = db.transaction('nexradFrames', 'readwrite');
+            tx.objectStore('nexradFrames').put(rec);
+            await new Promise((res, rej) => { tx.oncomplete = res; tx.onerror = () => rej(tx.error); });
+            await this._purgeDb();
+        } catch (err) {
+            if (typeof DiagLog !== 'undefined') DiagLog.log('error', `radar persist failed: ${err.message}`);
+        }
+    }
+
+    async _purgeDb() {
+        const db = await this._openDb();
+        const cutoff = Date.now() - this._cacheHours * 3600000;
+        const tx = db.transaction('nexradFrames', 'readwrite');
+        const store = tx.objectStore('nexradFrames');
+        store.openCursor().onsuccess = (e) => {
+            const cur = e.target.result;
+            if (!cur) return;
+            if ((cur.value.time || 0) < cutoff) cur.delete();
+            cur.continue();
+        };
     }
 
     _purgeOld() {

--- a/web/cockpit/fisb-nexrad.js
+++ b/web/cockpit/fisb-nexrad.js
@@ -950,6 +950,36 @@ class FisbNexrad {
         return 0;
     }
 
+    /** Export cached frames as NDJSON to the on-device server (next to flight CSVs). */
+    async exportFrames() {
+        const lines = this._frameHistory.map(snap => {
+            const NEXRAD = [];
+            for (const [, b] of snap.blocks) NEXRAD.push({
+                Radar_Type: b.radarType, Scale: b.scale,
+                LatNorth: b.latN, LonWest: b.lonW, Height: b.height, Width: b.width,
+                Intensity: Array.from(b.intensity),
+            });
+            return JSON.stringify({ Product_id: 63, NEXRAD,
+                LocaltimeReceived: new Date(snap.dataTime).toISOString() });
+        });
+        const iso = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+        const path = `flights/nexrad-${iso}.ndjson`;
+        const base = (typeof FlightRecorder !== 'undefined' && FlightRecorder.LOCAL_BASE)
+            ? FlightRecorder.LOCAL_BASE : 'http://localhost:9090';
+        try {
+            const resp = await fetch(`${base}/${path}`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/x-ndjson' },
+                body: lines.join('\n'),
+            });
+            if (typeof DiagLog !== 'undefined') DiagLog.log('radar', `exportFrames → ${path} (${lines.length} frames, ok=${resp.ok})`);
+            return { ok: resp.ok, path, frames: lines.length };
+        } catch (err) {
+            if (typeof DiagLog !== 'undefined') DiagLog.log('error', `exportFrames failed: ${err.message}`);
+            return { ok: false, path, frames: lines.length, error: err.message };
+        }
+    }
+
     /** Web mercator tile coordinate helpers. */
     static _lon2tile(lon, z) {
         return Math.floor((lon + 180) / 360 * Math.pow(2, z));

--- a/web/cockpit/fisb-nexrad.js
+++ b/web/cockpit/fisb-nexrad.js
@@ -116,6 +116,13 @@ class FisbNexrad {
 
         // Redraw on any map movement (including during panning)
         map.on('move zoom moveend zoomend', this._onMove);
+
+        // If hydrated frames already exist from a prior session, switch the loop source to
+        // FIS-B now instead of waiting for the next live snapshot (up to frameIntervalMinutes).
+        if (!this._loopReadyFired && this._frameHistory.length >= 2) {
+            this._loopReadyFired = true;
+            window.app?.cockpitMap?.onFisbNexradLoopReady?.();
+        }
     }
 
     /** Remove overlay from map */
@@ -325,6 +332,9 @@ class FisbNexrad {
             while (this._frameHistory.length > this._maxFrames) this._frameHistory.shift();
             // Seed live blocks + per-product age from the newest frame so the map/page
             // show SOMETHING immediately on reopen; a live frame will overwrite by key.
+            // NOTE: these seeded blocks keep their original received_at, so _purgeOld() may
+            // sweep them within ~15 min if the cache is old — that's intended. The durable
+            // benefit of hydration is _frameHistory (the loop); the live-view seed is a bonus.
             const last = this._frameHistory[this._frameHistory.length - 1];
             if (last) {
                 for (const [, b] of last.blocks) {

--- a/web/cockpit/fisb-nexrad.js
+++ b/web/cockpit/fisb-nexrad.js
@@ -20,7 +20,11 @@ class FisbNexrad {
 
         // Frame history for radar loop playback (ring buffer of snapshots)
         this._frameHistory = [];
-        this._maxFrames = 24; // ~60 min at 2.5 min intervals
+        const intervalMin = CockpitConfig.get('radar.frameIntervalMinutes') || 10;
+        const durationHr  = CockpitConfig.get('radar.loopDurationHours') || 2;
+        this._cacheHours  = CockpitConfig.get('radar.cacheHours') || 3;
+        this._snapIntervalMs = intervalMin * 60000;
+        this._maxFrames = Math.max(2, Math.ceil(durationHr * 60 / intervalMin));
 
         // Config
         this._opacity = CockpitConfig.get('radar.opacity') || 0.5;
@@ -203,7 +207,7 @@ class FisbNexrad {
         // Snapshot for radar loop (throttled to every 2.5 minutes)
         const lastSnap = this._frameHistory.length > 0
             ? this._frameHistory[this._frameHistory.length - 1].time : 0;
-        if (now - lastSnap >= 150000) { // 2.5 minutes
+        if (now - lastSnap >= this._snapIntervalMs) {
             this._takeSnapshot(now, dataTime);
             // Notify map to switch the loop source to FIS-B once we have enough frames to animate.
             // Two frames = minimum for visible animation. Fire once per radar session.

--- a/web/cockpit/fisb-nexrad.js
+++ b/web/cockpit/fisb-nexrad.js
@@ -257,7 +257,10 @@ class FisbNexrad {
                     db.createObjectStore('nexradFrames', { keyPath: 'dataTime' });
             };
             req.onsuccess = () => resolve(req.result);
-            req.onerror = () => reject(req.error);
+            // Clear the cached promise on failure so the next call retries instead of
+            // returning a permanently-rejected promise (a transient IDB open error on
+            // Android would otherwise silently disable persistence for the whole session).
+            req.onerror = () => { this._dbPromise = null; reject(req.error); };
         });
         return this._dbPromise;
     }
@@ -288,6 +291,9 @@ class FisbNexrad {
             if ((cur.value.time || 0) < cutoff) cur.delete();
             cur.continue();
         };
+        // Resolve only when the deletes have actually committed, so callers that await
+        // _purgeDb() (and the try/catch around them) see cursor/tx errors.
+        await new Promise((res, rej) => { tx.oncomplete = res; tx.onerror = () => rej(tx.error); });
     }
 
     _purgeOld() {

--- a/web/cockpit/fisb-nexrad.js
+++ b/web/cockpit/fisb-nexrad.js
@@ -129,6 +129,7 @@ class FisbNexrad {
         this._frameHistory = [];
         this._canvas = null;
         this._ctx = null;
+        this._mainTarget = null;   // drop stale canvas/ctx ref so _draw()'s guard fires after teardown
         this._clearCbOverlays();
         this._stopInetSampling();
         this._map = null;

--- a/web/cockpit/fisb-nexrad.js
+++ b/web/cockpit/fisb-nexrad.js
@@ -952,6 +952,10 @@ class FisbNexrad {
 
     /** Export cached frames as NDJSON to the on-device server (next to flight CSVs). */
     async exportFrames() {
+        if (!this._frameHistory.length) {
+            if (typeof DiagLog !== 'undefined') DiagLog.log('radar', 'exportFrames: no frames to export');
+            return { ok: true, path: null, frames: 0 };
+        }
         const lines = this._frameHistory.map(snap => {
             const NEXRAD = [];
             for (const [, b] of snap.blocks) NEXRAD.push({
@@ -959,7 +963,11 @@ class FisbNexrad {
                 LatNorth: b.latN, LonWest: b.lonW, Height: b.height, Width: b.width,
                 Intensity: Array.from(b.intensity),
             });
-            return JSON.stringify({ Product_id: 63, NEXRAD,
+            // A snapshot bundles whatever was in _blocks (often BOTH products), so there is no
+            // single true message PID; stamp it from the first block. The app's replay keys off
+            // each block's Radar_Type via _productOf(), so the message PID is informational only.
+            const pid = NEXRAD[0]?.Radar_Type ?? 63;
+            return JSON.stringify({ Product_id: pid, NEXRAD,
                 LocaltimeReceived: new Date(snap.dataTime).toISOString() });
         });
         const iso = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);

--- a/web/cockpit/fisb-nexrad.js
+++ b/web/cockpit/fisb-nexrad.js
@@ -100,6 +100,7 @@ class FisbNexrad {
         this._canvas.className = 'fisb-nexrad-canvas';
         map.getPanes().overlayPane.appendChild(this._canvas);
         this._ctx = this._canvas.getContext('2d');
+        this._mainTarget = { map, canvas: this._canvas, ctx: this._ctx };
 
         // Size canvas
         this._resizeCanvas();
@@ -255,38 +256,40 @@ class FisbNexrad {
         if (!this._loopMode) this._draw();
     }
 
-    /** Draw all NEXRAD blocks onto canvas */
-    _draw() {
-        if (!this._ctx || !this._map || !this._active) return;
+    /** Public: draw current blocks of one product to a target. */
+    draw(target, product) {
+        this._drawToTarget(target, product, this._blocks);
+    }
 
-        const ctx = this._ctx;
-        const map = this._map;
+    /** Draw a block map (live or snapshot) of one product onto a target's canvas. */
+    _drawToTarget(target, product, blockMap) {
+        const { map, canvas, ctx } = target;
+        if (!ctx || !map) return;
 
-        // Position canvas at the map's pixel origin so it aligns with panning
         const topLeft = map.containerPointToLayerPoint([0, 0]);
-        this._canvas.style.transform = `translate(${topLeft.x}px, ${topLeft.y}px)`;
+        canvas.style.transform = `translate(${topLeft.x}px, ${topLeft.y}px)`;
+        ctx.clearRect(0, 0, canvas.width, canvas.height);
+        if (blockMap.size === 0) return;
 
-        ctx.clearRect(0, 0, this._canvas.width, this._canvas.height);
-
-        if (this._blocks.size === 0) return;
-
-        // Apply configured opacity
         ctx.globalAlpha = this._opacity;
-
         const bounds = map.getBounds();
         const zoom = map.getZoom();
 
-        for (const [, block] of this._blocks) {
-            // Quick bounds check — skip blocks outside viewport
+        for (const [, block] of blockMap) {
+            if (FisbNexrad._productOf(block) !== product) continue;
             const blockS = block.latN - block.height;
             const blockE = block.lonW + block.width;
             if (block.latN < bounds.getSouth() || blockS > bounds.getNorth()) continue;
             if (blockE < bounds.getWest() || block.lonW > bounds.getEast()) continue;
-
             this._drawBlock(ctx, map, block, zoom);
         }
-
         ctx.globalAlpha = 1.0;
+    }
+
+    /** Draw the main-map live view — Regional product only. */
+    _draw() {
+        if (!this._active || !this._mainTarget) return;
+        this._drawToTarget(this._mainTarget, 'regional', this._blocks);
     }
 
     /** Draw a single NEXRAD block */
@@ -328,36 +331,12 @@ class FisbNexrad {
         }
     }
 
-    /** Draw a specific historical frame (for radar loop) */
-    drawFrame(frameIndex) {
-        if (!this._ctx || !this._map) return;
+    /** Draw a specific historical frame of one product onto a target (radar loop). */
+    drawFrame(target, product, frameIndex) {
         if (frameIndex < 0 || frameIndex >= this._frameHistory.length) return;
-
-        const ctx = this._ctx;
-        const map = this._map;
-
-        // Sync canvas position with map pane
-        const topLeft = map.containerPointToLayerPoint([0, 0]);
-        this._canvas.style.transform = `translate(${topLeft.x}px, ${topLeft.y}px)`;
-
-        ctx.clearRect(0, 0, this._canvas.width, this._canvas.height);
-        ctx.globalAlpha = this._opacity;
-
-        const snapshot = this._frameHistory[frameIndex];
-        if (!snapshot) return;
-
-        const bounds = map.getBounds();
-        const zoom = map.getZoom();
-
-        for (const [, block] of snapshot.blocks) {
-            const blockS = block.latN - block.height;
-            const blockE = block.lonW + block.width;
-            if (block.latN < bounds.getSouth() || blockS > bounds.getNorth()) continue;
-            if (blockE < bounds.getWest() || block.lonW > bounds.getEast()) continue;
-            this._drawBlock(ctx, map, block, zoom);
-        }
-
-        ctx.globalAlpha = 1.0;
+        const snap = this._frameHistory[frameIndex];
+        if (!snap) return;
+        this._drawToTarget(target, product, snap.blocks);
     }
 
     /** Enter loop mode (suppress live draws) */

--- a/web/cockpit/fisb-nexrad.js
+++ b/web/cockpit/fisb-nexrad.js
@@ -12,8 +12,11 @@ class FisbNexrad {
         this._ctx = null;
         this._active = false;
 
-        // NEXRAD block store: "latN,lonW" → { latN, lonW, height, width, intensity[], received_at }
+        // NEXRAD block store: "latN,lonW" → { latN, lonW, height, width, intensity[], radarType, scale, received_at }
         this._blocks = new Map();
+
+        // Per-product freshness: tracks the most recent received_at for each product type
+        this._newestAt = { regional: 0, conus: 0 };
 
         // Frame history for radar loop playback (ring buffer of snapshots)
         this._frameHistory = [];
@@ -67,6 +70,11 @@ class FisbNexrad {
         'rgba(255, 0, 255, 0.8)',     // 6: very heavy
         'rgba(255, 255, 255, 0.9)',   // 7+: extreme
     ];
+
+    /** Classify a stored block by FIS-B product. */
+    static _productOf(block) {
+        return (block.radarType === 64 || block.scale > 0) ? 'conus' : 'regional';
+    }
 
     // ========== Public API ==========
 
@@ -171,14 +179,19 @@ class FisbNexrad {
             if (!block.Intensity || block.Intensity.length === 0) continue;
 
             const key = `${block.LatNorth},${block.LonWest}`;
-            this._blocks.set(key, {
+            const stored = {
                 latN: block.LatNorth,
                 lonW: block.LonWest,
                 height: block.Height,
                 width: block.Width,
                 intensity: block.Intensity,
+                radarType: block.Radar_Type,   // 63 Regional | 64 CONUS
+                scale: block.Scale,             // 0 | 1 | 2
                 received_at: now,
-            });
+            };
+            this._blocks.set(key, stored);
+            const p = FisbNexrad._productOf(stored);
+            if (now > this._newestAt[p]) this._newestAt[p] = now;
         }
 
         // Snapshot for radar loop (throttled to every 2.5 minutes)

--- a/web/cockpit/fisb-nexrad.js
+++ b/web/cockpit/fisb-nexrad.js
@@ -61,6 +61,10 @@ class FisbNexrad {
         this._cbLabelMarkers = [];   // L.marker[] for CB↑ labels
         this._cbInetLayer = null;    // L.tileLayer ref (internet radar) for ground-mode sampling
         this._cbInetTimer = null;    // interval for periodic internet re-sampling
+
+        // Restore persisted frame history so the loop and map show data immediately
+        // on reopen (fire-and-forget; live frames augment _blocks/_frameHistory as they arrive).
+        this._hydrate();
     }
 
     // Standard NEXRAD intensity → color map (0-7+)
@@ -294,6 +298,44 @@ class FisbNexrad {
         // Resolve only when the deletes have actually committed, so callers that await
         // _purgeDb() (and the try/catch around them) see cursor/tx errors.
         await new Promise((res, rej) => { tx.oncomplete = res; tx.onerror = () => rej(tx.error); });
+    }
+
+    async _hydrate() {
+        try {
+            const db = await this._openDb();
+            const cutoff = Date.now() - this._cacheHours * 3600000;
+            const tx = db.transaction('nexradFrames', 'readonly');
+            const recs = await new Promise((res, rej) => {
+                const r = tx.objectStore('nexradFrames').getAll();
+                r.onsuccess = () => res(r.result || []); r.onerror = () => rej(r.error);
+            });
+            // Skip dataTimes already present from live frames that arrived during the
+            // async open, so hydration never duplicates or interleaves with live data.
+            const seen = new Set(this._frameHistory.map(f => f.dataTime));
+            const fresh = recs.filter(r => (r.time || 0) >= cutoff && !seen.has(r.dataTime))
+                              .sort((a, b) => a.dataTime - b.dataTime)
+                              .slice(-this._maxFrames);
+            for (const r of fresh) {
+                const m = new Map();
+                for (const b of r.blocks) m.set(`${b.latN},${b.lonW}`, b);
+                this._frameHistory.push({ time: r.time, dataTime: r.dataTime, blocks: m });
+            }
+            // Keep newest-last ordering and the ring cap even if a live frame raced in.
+            this._frameHistory.sort((a, b) => a.dataTime - b.dataTime);
+            while (this._frameHistory.length > this._maxFrames) this._frameHistory.shift();
+            // Seed live blocks + per-product age from the newest frame so the map/page
+            // show SOMETHING immediately on reopen; a live frame will overwrite by key.
+            const last = this._frameHistory[this._frameHistory.length - 1];
+            if (last) {
+                for (const [, b] of last.blocks) {
+                    this._blocks.set(`${b.latN},${b.lonW}`, b);
+                    const p = FisbNexrad._productOf(b);
+                    this._newestAt[p] = Math.max(this._newestAt[p], last.time);
+                }
+            }
+        } catch (err) {
+            if (typeof DiagLog !== 'undefined') DiagLog.log('error', `radar hydrate failed: ${err.message}`);
+        }
     }
 
     _purgeOld() {

--- a/web/cockpit/fisb-status.js
+++ b/web/cockpit/fisb-status.js
@@ -206,19 +206,28 @@ class FisbStatus {
             return;
         }
 
-        entries.sort((a, b) => (b[1].Signal_strength_last_minute || 0) - (a[1].Signal_strength_last_minute || 0));
+        // Sort active towers first (≥ -100), then silent towers last.
+        // -999 is Stratux's sentinel for "tower seen but no signal measured"; treat as 0 for sort.
+        entries.sort((a, b) => {
+            const sa = a[1].Signal_strength_last_minute ?? -999;
+            const sb = b[1].Signal_strength_last_minute ?? -999;
+            const sortA = sa <= -100 ? -9999 : sa;
+            const sortB = sb <= -100 ? -9999 : sb;
+            return sortB - sortA;
+        });
 
         container.innerHTML = `<table class="fisb-tower-table">
             <thead><tr><th>LOCATION</th><th>SIGNAL</th><th>MSG/MIN</th></tr></thead>
             <tbody>${entries.map(([coords, t]) => {
-                const sig = t.Signal_strength_last_minute != null ? t.Signal_strength_last_minute.toFixed(0) : '?';
-                const sigNum = parseFloat(sig);
-                const cls = sigNum >= -10 ? 'ok' : sigNum >= -15 ? 'warn' : 'bad';
+                const rawSig = t.Signal_strength_last_minute;
+                const noSignal = rawSig == null || rawSig <= -100; // -999 = Stratux sentinel
+                const sig = noSignal ? '—' : rawSig.toFixed(0);
+                const cls = noSignal ? 'bad' : rawSig >= -10 ? 'ok' : rawSig >= -15 ? 'warn' : 'bad';
                 const lat = t.Lat != null ? t.Lat.toFixed(2) : '?';
                 const lng = t.Lng != null ? t.Lng.toFixed(2) : '?';
                 return `<tr>
                     <td>${lat}, ${lng}</td>
-                    <td class="fisb-tower-sig ${cls}">${sig} dB</td>
+                    <td class="fisb-tower-sig ${cls}">${sig}${noSignal ? '' : ' dB'}</td>
                     <td>${t.Messages_last_minute || 0}</td>
                 </tr>`;
             }).join('')}</tbody>

--- a/web/cockpit/fuel-tanks.js
+++ b/web/cockpit/fuel-tanks.js
@@ -121,8 +121,13 @@ class FuelTanksDisplay {
                     <div class="ftw-sender" id="ftw-sender-l"></div>
                 </div>
                 <div class="ftw-center">
-                    <div class="ftw-total-lbl">TOT</div>
+                    <div class="ftw-center-label">T</div>
+                    <div class="ftw-bar-wrap ftw-bar-wrap-center">
+                        <div class="ftw-bar-fill" id="ftw-bar-total"></div>
+                    </div>
                     <div class="ftw-total" id="ftw-total">--</div>
+                    <div class="ftw-flow-lbl">GPH</div>
+                    <div class="ftw-flow" id="ftw-flow">--</div>
                     <div class="ftw-end" id="ftw-end">--</div>
                     <div class="ftw-imbal" id="ftw-imbal" style="display:none">⚠</div>
                 </div>
@@ -180,7 +185,9 @@ class FuelTanksDisplay {
             badgeR:        this._el.querySelector('#ftw-badge-r'),
             senderL:       this._el.querySelector('#ftw-sender-l'),
             senderR:       this._el.querySelector('#ftw-sender-r'),
+            barTotal:      this._el.querySelector('#ftw-bar-total'),
             total:         this._el.querySelector('#ftw-total'),
+            flow:          this._el.querySelector('#ftw-flow'),
             end:           this._el.querySelector('#ftw-end'),
             imbal:         this._el.querySelector('#ftw-imbal'),
             initPanel:     this._el.querySelector('#ftw-init-panel'),
@@ -359,6 +366,10 @@ class FuelTanksDisplay {
         const total = state.left_gal + state.right_gal;
         this._dom.total.textContent = total.toFixed(1) + 'g';
 
+        const pctTotal = Math.min(1, Math.max(0, total / (this._tankCapacity * 2)));
+        this._dom.barTotal.style.height = (pctTotal * 100).toFixed(1) + '%';
+        this._dom.barTotal.className = barCls(total / 2);
+
         this._dom.imbal.style.display = state.imbalance ? '' : 'none';
 
         this._updateTimers();
@@ -371,11 +382,14 @@ class FuelTanksDisplay {
         this._dom.timerL.textContent = '';
         this._dom.timerR.textContent = '';
         this._dom.total.textContent = '--';
+        this._dom.flow.textContent = '--';
         this._dom.end.textContent = '--';
         this._dom.barL.style.height = '0%';
         this._dom.barR.style.height = '0%';
+        this._dom.barTotal.style.height = '0%';
         this._dom.barL.className = 'ftw-bar-fill';
         this._dom.barR.className = 'ftw-bar-fill';
+        this._dom.barTotal.className = 'ftw-bar-fill';
         this._dom.tankL.classList.remove('ftw-tank-active');
         this._dom.tankR.classList.remove('ftw-tank-active');
         this._dom.imbal.style.display = 'none';
@@ -386,9 +400,11 @@ class FuelTanksDisplay {
         if (!state || FuelTankState.needsConfirmation()) return;
         const total = state.left_gal + state.right_gal;
         if (this._lastGph > 0) {
+            this._dom.flow.textContent = this._lastGph.toFixed(1);
             const { hours, minutes } = FuelEngine.endurance(total, this._lastGph);
             this._dom.end.textContent = `${hours}:${String(minutes).padStart(2, '0')}`;
         } else {
+            this._dom.flow.textContent = '--';
             this._dom.end.textContent = '--';
         }
     }

--- a/web/cockpit/map.js
+++ b/web/cockpit/map.js
@@ -764,6 +764,11 @@ class CockpitMap {
                 }
             );
             this.radarLayer.addTo(this.map);
+            // Badge — show immediately on enable, then refresh every 30 s
+            this._updateRadarBadge();
+            if (!this._radarBadgeTimer) {
+                this._radarBadgeTimer = setInterval(() => this._updateRadarBadge(), 30000);
+            }
             // Tell FisbNexrad about the internet tile layer so CB building can sample it
             if (this._fisbNexrad) this._fisbNexrad.setCbInternetLayer(this.radarLayer);
             // Internet source — always used as the initial loop source so playback works
@@ -790,6 +795,9 @@ class CockpitMap {
             }
             this.map.removeLayer(this.radarLayer);
             this.radarLayer = null;
+            // Hide badge and stop refresh timer
+            if (this._radarBadge) this._radarBadge.style.display = 'none';
+            clearInterval(this._radarBadgeTimer); this._radarBadgeTimer = null;
         }
     }
 
@@ -800,6 +808,7 @@ class CockpitMap {
      */
     onFisbNexradData() {
         if (this.radarLayer) this.radarLayer.setOpacity(0.3);
+        this._updateRadarBadge();
     }
 
     /**
@@ -811,6 +820,21 @@ class CockpitMap {
         if (this._radarLoop && this._fisbNexrad) {
             this._radarLoop.setNexrad(this._fisbNexrad);
         }
+    }
+
+    _updateRadarBadge() {
+        if (!this._fisbNexrad) return;
+        const el = this._radarBadge || (this._radarBadge = (() => {
+            const d = document.createElement('div');
+            d.className = 'radar-badge';
+            this.container.appendChild(d);
+            return d;
+        })());
+        const ageMs = this._fisbNexrad.getDataAgeMs('regional');
+        if (ageMs == null) { el.style.display = 'none'; return; }
+        const min = Math.round(ageMs / 60000);
+        el.style.display = 'block';
+        el.textContent = `FIS-B · Regional · ${min} min`;
     }
 
     toggleCbBuilding(on) {

--- a/web/cockpit/map.js
+++ b/web/cockpit/map.js
@@ -291,6 +291,7 @@ class CockpitMap {
         }
         if (this._trafficTimer) { clearInterval(this._trafficTimer); this._trafficTimer = null; }
         if (this._fixUpdateTimer) { clearTimeout(this._fixUpdateTimer); this._fixUpdateTimer = null; }
+        if (this._radarBadgeTimer) { clearInterval(this._radarBadgeTimer); this._radarBadgeTimer = null; }
         if (this._zoomBadgeHandler && this.map) { this.map.off('zoomend', this._zoomBadgeHandler); this._zoomBadgeHandler = null; }
         if (this._viewportResizeHandler && window.visualViewport) {
             window.visualViewport.removeEventListener('resize', this._viewportResizeHandler);
@@ -808,7 +809,7 @@ class CockpitMap {
      */
     onFisbNexradData() {
         if (this.radarLayer) this.radarLayer.setOpacity(0.3);
-        this._updateRadarBadge();
+        if (this.radarLayer) this._updateRadarBadge();
     }
 
     /**

--- a/web/cockpit/radar-loop.js
+++ b/web/cockpit/radar-loop.js
@@ -200,7 +200,10 @@ class RadarLoop {
 
         this._frameIndex = index;
 
-        // Tell FisbNexrad to render this historical frame
+        // Tell FisbNexrad to render this historical frame.
+        // NOTE: drawFrame signature is now (target, product, frameIndex). This single-arg
+        // call is a safe no-op until Task 5 makes RadarLoop target-aware. Do not "fix" by
+        // guessing args here — Task 5 rewires this call site.
         if (this._nexrad) {
             this._nexrad.drawFrame(index);
         }

--- a/web/cockpit/radar-loop.js
+++ b/web/cockpit/radar-loop.js
@@ -5,7 +5,7 @@
  */
 
 class RadarLoop {
-    constructor() {
+    constructor(opts = {}) {
         this._map = null;
         this._active = false;
         this._playing = false;
@@ -17,6 +17,10 @@ class RadarLoop {
         // FIS-B canvas renderer — always suppressed during loop so it doesn't overdraw
         // internet tile frames. Same as _nexrad when FIS-B is the active source.
         this._fisbRenderer = null;
+
+        // Target + product for FIS-B canvas rendering. null target → use renderer's _mainTarget.
+        this._target  = opts.target  || null;     // {map,canvas,ctx}; null → renderer's main target
+        this._product = opts.product || 'regional';
 
         // Config
         this._speedMs = CockpitConfig.get('radar.playbackSpeedMs') || 500;
@@ -200,12 +204,16 @@ class RadarLoop {
 
         this._frameIndex = index;
 
-        // Tell FisbNexrad to render this historical frame.
-        // NOTE: drawFrame signature is now (target, product, frameIndex). This single-arg
-        // call is a safe no-op until Task 5 makes RadarLoop target-aware. Do not "fix" by
-        // guessing args here — Task 5 rewires this call site.
+        // Render this historical frame.
         if (this._nexrad) {
-            this._nexrad.drawFrame(index);
+            if (this._nexrad === this._fisbRenderer) {
+                // FIS-B canvas renderer: needs an explicit target + product filter
+                const target = this._target || this._fisbRenderer._mainTarget;
+                if (target) this._fisbRenderer.drawFrame(target, this._product, index);
+            } else {
+                // Internet tile source: original signature (toggles tile-layer opacity)
+                this._nexrad.drawFrame(index);
+            }
         }
 
         this._updateTimeDisplay();

--- a/web/cockpit/radar-page.js
+++ b/web/cockpit/radar-page.js
@@ -1,0 +1,138 @@
+/**
+ * FlyTab — CONUS Radar Page
+ * Full-screen dedicated FIS-B CONUS NEXRAD view: own Leaflet map, ownship icon,
+ * SE-wide default zoom, pan/zoom + recenter, product/age badge.
+ * Reuses the shared FisbNexrad data layer (renders product 'conus' to its own target).
+ *
+ * Independent of the main CockpitMap: owns its own L.map instance, its own overlay
+ * canvas, and its own ownship marker. Does NOT touch the main map, the route editor,
+ * or the main map's tap handlers.
+ */
+class RadarPage {
+    constructor(fisbNexrad, stratuxClient) {
+        this._fisb = fisbNexrad;
+        this._stratux = stratuxClient;
+        this._visible = false;
+        this._map = null;
+        this._canvas = null;
+        this._ctx = null;
+        this._target = null;
+        this._ownship = null;
+        this._ownPos = null;
+        this._badge = null;
+        this._ageTimer = null;
+        this._defaultZoom = (typeof CockpitConfig !== 'undefined' && CockpitConfig.get)
+            ? (CockpitConfig.get('radar.conusDefaultZoom') || 6) : 6;
+
+        this._onSituation = (e) => this._updateOwnship(e.detail);
+        this._onNexrad = () => { if (this._visible) { this._drawConus(); this._updateBadge(); } };
+        this._buildDom();
+    }
+
+    _buildDom() {
+        this._el = document.createElement('div');
+        this._el.className = 'radar-page';
+        this._el.style.display = 'none';
+        this._el.innerHTML = `
+            <div class="radar-page-header">
+                <span class="radar-page-title">CONUS Radar</span>
+                <span class="radar-badge radar-page-badge"></span>
+                <button class="radar-page-close" aria-label="Close">&#x2715;</button>
+            </div>
+            <div class="radar-page-map"></div>
+            <button class="radar-page-recenter">Recenter on me</button>`;
+        document.body.appendChild(this._el);
+        this._mapEl = this._el.querySelector('.radar-page-map');
+        this._badge = this._el.querySelector('.radar-page-badge');
+        this._el.querySelector('.radar-page-close').addEventListener('click', () => this.hide());
+        this._el.querySelector('.radar-page-recenter').addEventListener('click', () => this._recenter());
+    }
+
+    _ensureMap() {
+        if (this._map) return;
+        const tileBase = 'http://localhost:9090/tiles';
+        this._map = L.map(this._mapEl, { zoomControl: true, attributionControl: false });
+        L.tileLayer(`${tileBase}/sectional/{z}/{x}/{y}.webp`, { minZoom: 4, maxZoom: 14 }).addTo(this._map);
+        this._map.setView([35.0, -80.0], this._defaultZoom); // initial; recentre on first fix
+
+        // Overlay canvas lives in the map's overlay pane so it pans/zooms with the map.
+        // Oversized (2x container) to cover the pan-offset translate the FisbNexrad
+        // renderer applies — matches the main-map convention in fisb-nexrad.js.
+        this._canvas = document.createElement('canvas');
+        this._canvas.style.cssText = 'position:absolute;top:0;left:0;pointer-events:none;';
+        this._canvas.className = 'fisb-nexrad-canvas';
+        this._map.getPanes().overlayPane.appendChild(this._canvas);
+        this._ctx = this._canvas.getContext('2d');
+        this._target = { map: this._map, canvas: this._canvas, ctx: this._ctx };
+
+        const size = () => {
+            const s = this._map.getSize();
+            this._canvas.width = s.x * 2;
+            this._canvas.height = s.y * 2;
+        };
+        size();
+        this._map.on('resize', () => { size(); this._drawConus(); });
+        this._map.on('move zoom moveend zoomend', () => this._drawConus());
+    }
+
+    _drawConus() { if (this._target) this._fisb.draw(this._target, 'conus'); }
+
+    _updateOwnship(sit) {
+        if (!sit || sit.lat == null || sit.lon == null) return;
+        this._ownPos = { lat: sit.lat, lon: sit.lon, course: sit.true_course || 0 };
+        if (!this._visible || !this._map) return;
+        const pos = [sit.lat, sit.lon];
+        if (!this._ownship) {
+            const icon = L.divIcon({
+                className: 'ownship-icon',
+                html: CockpitMap._ownshipSvg(this._ownPos.course),
+                iconSize: [48, 48],
+                iconAnchor: [24, 24],
+            });
+            this._ownship = L.marker(pos, { icon, zIndexOffset: 1000 }).addTo(this._map);
+        } else {
+            this._ownship.setLatLng(pos);
+            const g = this._ownship.getElement()?.querySelector('svg g');
+            if (g) g.setAttribute('transform', `rotate(${this._ownPos.course}, 24, 24)`);
+        }
+    }
+
+    _recenter() {
+        if (this._ownPos && this._map) this._map.setView([this._ownPos.lat, this._ownPos.lon], this._defaultZoom);
+    }
+
+    _updateBadge() {
+        const ageMs = this._fisb.getDataAgeMs('conus');
+        this._badge.textContent = ageMs == null
+            ? 'FIS-B · CONUS · no data'
+            : `FIS-B · CONUS · ${Math.round(ageMs / 60000)} min`;
+    }
+
+    isVisible() { return this._visible; }
+
+    show() {
+        this._visible = true;
+        this._el.style.display = 'flex';
+        this._ensureMap();
+        setTimeout(() => {
+            this._map.invalidateSize();
+            this._recenter();
+            this._drawConus();
+        }, 0);
+        this._stratux.addEventListener('stratux:situation', this._onSituation);
+        this._stratux.addEventListener('stratux:nexrad', this._onNexrad);
+        if (this._ownPos) {
+            this._updateOwnship({ lat: this._ownPos.lat, lon: this._ownPos.lon, true_course: this._ownPos.course });
+        }
+        this._updateBadge();
+        this._ageTimer = setInterval(() => this._updateBadge(), 30000);
+    }
+
+    hide() {
+        this._visible = false;
+        this._el.style.display = 'none';
+        this._stratux.removeEventListener('stratux:situation', this._onSituation);
+        this._stratux.removeEventListener('stratux:nexrad', this._onNexrad);
+        if (this._ageTimer) { clearInterval(this._ageTimer); this._ageTimer = null; }
+    }
+}

--- a/web/cockpit/radar-page.js
+++ b/web/cockpit/radar-page.js
@@ -46,6 +46,7 @@ class RadarPage {
             <div class="radar-page-header">
                 <span class="radar-page-title">CONUS Radar</span>
                 <span class="radar-badge radar-page-badge"></span>
+                <button class="radar-page-export">Export</button>
                 <button class="radar-page-close" aria-label="Close">&#x2715;</button>
             </div>
             <div class="radar-page-map">
@@ -59,6 +60,7 @@ class RadarPage {
         document.body.appendChild(this._el);
         this._mapEl = this._el.querySelector('.radar-page-map');
         this._badge = this._el.querySelector('.radar-page-badge');
+        this._el.querySelector('.radar-page-export').addEventListener('click', () => this._fisb.exportFrames());
         this._el.querySelector('.radar-page-close').addEventListener('click', () => this.hide());
         this._el.querySelector('.radar-page-recenter').addEventListener('click', () => this._recenter());
         this._el.querySelector('.radar-page-loop-btn').addEventListener('click', () => this._toggleLoop());

--- a/web/cockpit/radar-page.js
+++ b/web/cockpit/radar-page.js
@@ -88,8 +88,11 @@ class RadarPage {
             this._canvas.height = s.y * 2;
         };
         size();
-        this._map.on('resize', () => { size(); this._drawConus(); });
-        this._map.on('move zoom moveend zoomend', () => this._drawConus());
+        // While looping/scrubbing, a map nudge must re-draw the CURRENT historical frame,
+        // not the live composite — otherwise panning wipes the frame the pilot is reading.
+        const redraw = () => { if (this._looping) this._showFrame(this._loopIdx); else this._drawConus(); };
+        this._map.on('resize', () => { size(); redraw(); });
+        this._map.on('move zoom moveend zoomend', redraw);
     }
 
     _drawConus() { if (this._target) this._fisb.draw(this._target, 'conus'); }
@@ -192,6 +195,7 @@ class RadarPage {
         this._ensureMap();
         // Start in LIVE mode — pilot presses play to animate.
         this._looping = false;
+        this._loopIdx = 0;
         this._updateLoopBtn();
         setTimeout(() => {
             if (!this._visible) return;   // hide() fired before this microtask

--- a/web/cockpit/radar-page.js
+++ b/web/cockpit/radar-page.js
@@ -39,8 +39,9 @@ class RadarPage {
                 <span class="radar-badge radar-page-badge"></span>
                 <button class="radar-page-close" aria-label="Close">&#x2715;</button>
             </div>
-            <div class="radar-page-map"></div>
-            <button class="radar-page-recenter">Recenter on me</button>`;
+            <div class="radar-page-map">
+                <button class="radar-page-recenter">Recenter on me</button>
+            </div>`;
         document.body.appendChild(this._el);
         this._mapEl = this._el.querySelector('.radar-page-map');
         this._badge = this._el.querySelector('.radar-page-badge');
@@ -111,10 +112,12 @@ class RadarPage {
     isVisible() { return this._visible; }
 
     show() {
+        if (this._visible) return;   // idempotent — avoid double listeners / orphaned badge timer
         this._visible = true;
         this._el.style.display = 'flex';
         this._ensureMap();
         setTimeout(() => {
+            if (!this._visible) return;   // hide() fired before this microtask
             this._map.invalidateSize();
             this._recenter();
             this._drawConus();

--- a/web/cockpit/radar-page.js
+++ b/web/cockpit/radar-page.js
@@ -24,8 +24,17 @@ class RadarPage {
         this._defaultZoom = (typeof CockpitConfig !== 'undefined' && CockpitConfig.get)
             ? (CockpitConfig.get('radar.conusDefaultZoom') || 6) : 6;
 
+        this._looping = false;
+        this._loopIdx = 0;
+        this._loopTimer = null;
+        this._speedMs = (typeof CockpitConfig !== 'undefined' && CockpitConfig.get('radar.playbackSpeedMs')) || 500;
+
         this._onSituation = (e) => this._updateOwnship(e.detail);
-        this._onNexrad = () => { if (this._visible) { this._drawConus(); this._updateBadge(); } };
+        this._onNexrad = () => {
+            if (!this._visible) return;
+            if (!this._looping) this._drawConus();   // live view only when not looping
+            this._updateBadge();
+        };
         this._buildDom();
     }
 
@@ -41,12 +50,19 @@ class RadarPage {
             </div>
             <div class="radar-page-map">
                 <button class="radar-page-recenter">Recenter on me</button>
+                <div class="radar-page-loop">
+                    <button class="radar-page-loop-btn" aria-label="Play/pause loop">&#x25B6;</button>
+                    <span class="radar-page-loop-time"></span>
+                    <input type="range" class="radar-page-loop-scrubber" min="0" max="0" value="0" aria-label="Radar frame">
+                </div>
             </div>`;
         document.body.appendChild(this._el);
         this._mapEl = this._el.querySelector('.radar-page-map');
         this._badge = this._el.querySelector('.radar-page-badge');
         this._el.querySelector('.radar-page-close').addEventListener('click', () => this.hide());
         this._el.querySelector('.radar-page-recenter').addEventListener('click', () => this._recenter());
+        this._el.querySelector('.radar-page-loop-btn').addEventListener('click', () => this._toggleLoop());
+        this._el.querySelector('.radar-page-loop-scrubber').addEventListener('input', (e) => this._scrubTo(+e.target.value));
     }
 
     _ensureMap() {
@@ -109,6 +125,64 @@ class RadarPage {
             : `FIS-B · CONUS · ${Math.round(ageMs / 60000)} min`;
     }
 
+    _frames() { return this._fisb.frameHistory || []; }
+
+    _toggleLoop() {
+        if (this._looping) { this._pauseLoop(); return; }
+        const n = this._frames().length;
+        if (n < 2) return;               // need ≥2 frames to animate
+        this._looping = true;
+        this._updateLoopBtn();
+        this._loopTick();
+    }
+
+    _pauseLoop() {
+        this._looping = false;
+        if (this._loopTimer) { clearTimeout(this._loopTimer); this._loopTimer = null; }
+        this._updateLoopBtn();
+    }
+
+    _loopTick() {
+        const n = this._frames().length;
+        if (n === 0) { this._pauseLoop(); return; }
+        this._showFrame(this._loopIdx);
+        this._loopIdx = (this._loopIdx + 1) % n;
+        this._loopTimer = setTimeout(() => { if (this._looping) this._loopTick(); }, this._speedMs);
+    }
+
+    _scrubTo(i) {
+        this._pauseLoop();
+        this._loopIdx = i;
+        this._showFrame(i);
+    }
+
+    /** Draw one historical CONUS frame to the page canvas + sync the controls. */
+    _showFrame(i) {
+        const frames = this._frames();
+        if (i < 0 || i >= frames.length) return;
+        this._fisb.drawFrame(this._target, 'conus', i);
+        const scr = this._el.querySelector('.radar-page-loop-scrubber');
+        if (scr) { scr.max = String(frames.length - 1); scr.value = String(i); }
+        const t = this._el.querySelector('.radar-page-loop-time');
+        if (t) {
+            const f = frames[i];
+            const d = new Date(f.dataTime || f.time);
+            t.textContent = isNaN(d) ? '' : d.toISOString().slice(11, 16) + 'Z';
+        }
+    }
+
+    _updateLoopBtn() {
+        const b = this._el.querySelector('.radar-page-loop-btn');
+        if (b) b.textContent = this._looping ? '⏸' : '▶';
+    }
+
+    /** Refresh the scrubber range/label from current frame count without drawing. */
+    _refreshScrubber() {
+        const frames = this._frames();
+        const scr = this._el.querySelector('.radar-page-loop-scrubber');
+        if (scr) scr.max = String(Math.max(0, frames.length - 1));
+    }
+
     isVisible() { return this._visible; }
 
     show() {
@@ -116,11 +190,15 @@ class RadarPage {
         this._visible = true;
         this._el.style.display = 'flex';
         this._ensureMap();
+        // Start in LIVE mode — pilot presses play to animate.
+        this._looping = false;
+        this._updateLoopBtn();
         setTimeout(() => {
             if (!this._visible) return;   // hide() fired before this microtask
             this._map.invalidateSize();
             this._recenter();
             this._drawConus();
+            this._refreshScrubber();
         }, 0);
         this._stratux.addEventListener('stratux:situation', this._onSituation);
         this._stratux.addEventListener('stratux:nexrad', this._onNexrad);
@@ -133,6 +211,7 @@ class RadarPage {
 
     hide() {
         this._visible = false;
+        this._pauseLoop();
         this._el.style.display = 'none';
         this._stratux.removeEventListener('stratux:situation', this._onSituation);
         this._stratux.removeEventListener('stratux:nexrad', this._onNexrad);

--- a/web/cockpit/radar-page.js
+++ b/web/cockpit/radar-page.js
@@ -60,7 +60,7 @@ class RadarPage {
         document.body.appendChild(this._el);
         this._mapEl = this._el.querySelector('.radar-page-map');
         this._badge = this._el.querySelector('.radar-page-badge');
-        this._el.querySelector('.radar-page-export').addEventListener('click', () => this._fisb.exportFrames());
+        this._el.querySelector('.radar-page-export').addEventListener('click', (e) => this._onExport(e.target));
         this._el.querySelector('.radar-page-close').addEventListener('click', () => this.hide());
         this._el.querySelector('.radar-page-recenter').addEventListener('click', () => this._recenter());
         this._el.querySelector('.radar-page-loop-btn').addEventListener('click', () => this._toggleLoop());
@@ -128,6 +128,16 @@ class RadarPage {
         this._badge.textContent = ageMs == null
             ? 'FIS-B · CONUS · no data'
             : `FIS-B · CONUS · ${Math.round(ageMs / 60000)} min`;
+    }
+
+    /** Export cached frames to NDJSON with brief button feedback (cockpit needs confirmation). */
+    async _onExport(btn) {
+        const orig = btn.textContent;
+        btn.textContent = 'Saving…'; btn.disabled = true;
+        let r;
+        try { r = await this._fisb.exportFrames(); } catch { r = { ok: false }; }
+        btn.textContent = r.ok ? (r.frames ? `Saved ${r.frames}` : 'No frames') : 'Failed';
+        setTimeout(() => { btn.textContent = orig; btn.disabled = false; }, 2000);
     }
 
     _frames() { return this._fisb.frameHistory || []; }

--- a/web/cockpit/tab-bar.js
+++ b/web/cockpit/tab-bar.js
@@ -153,16 +153,6 @@ class TabBar {
                 this._closeMoreDrawer();
                 this._toggleTimer();
             }},
-            { icon: '⛽', label: 'Fuel Entry', action: () => {
-                if (c.fuelOverlay?.show) c.fuelOverlay.show();
-                this._hideRadarControls();
-                this._closeMoreDrawer();
-            }},
-            { icon: '⚖️', label: 'Weight & Balance', action: () => {
-                if (c.wbOverlay?.show) c.wbOverlay.show();
-                this._hideRadarControls();
-                this._closeMoreDrawer();
-            }},
             { icon: '📊', label: 'Approach Charts', action: () => {
                 if (c.approachCharts) {
                     c.approachCharts._currentPlate
@@ -189,6 +179,11 @@ class TabBar {
             }},
 
             { type: 'section', label: 'Pre / Post flight' },
+            { icon: '⛽', label: 'Fuel Entry', action: () => {
+                if (c.fuelOverlay?.show) c.fuelOverlay.show();
+                this._hideRadarControls();
+                this._closeMoreDrawer();
+            }},
             { icon: '✈️', label: 'Plan on flywhere.app', action: () => {
                 window.open('https://flywhere.app/plan', '_blank');
                 this._closeMoreDrawer();

--- a/web/cockpit/tab-bar.js
+++ b/web/cockpit/tab-bar.js
@@ -171,6 +171,11 @@ class TabBar {
                 this._hideRadarControls();
                 this._closeMoreDrawer();
             }},
+            { icon: '🌧', label: 'Radar', action: () => {
+                c.radarPage?.show();
+                this._hideRadarControls();
+                this._closeMoreDrawer();
+            }},
             { icon: '🧠', label: 'Engine ML', action: () => {
                 this._closeMoreDrawer();
                 this._hideRadarControls();

--- a/web/cockpit/tab-bar.js
+++ b/web/cockpit/tab-bar.js
@@ -102,6 +102,7 @@ class TabBar {
         if (c.planSync?.hide) c.planSync.hide();
         if (c.fisbStatus?.hide) c.fisbStatus.hide();
         if (c.flightUpload?.hide) c.flightUpload.hide();
+        if (c.radarPage?.hide) c.radarPage.hide();
         if (c.airportPopup?.close) c.airportPopup.close();
 
         // Hide radar loop controls when leaving map — they bleed through

--- a/web/index.html
+++ b/web/index.html
@@ -122,6 +122,7 @@
     <script src="./cockpit/fisb-weather.js"></script>
     <script src="./cockpit/fisb-status.js"></script>
     <script src="./cockpit/radar-loop.js"></script>
+    <script src="./cockpit/radar-page.js"></script>
     <script src="./cockpit/lightning.js"></script>
     <script src="./cockpit/ifr-clearance.js"></script>
     <script src="./cockpit/flight-sync.js"></script>

--- a/web/shared/cockpit-config.js
+++ b/web/shared/cockpit-config.js
@@ -87,6 +87,7 @@ class CockpitConfig {
             opacity: 0.5,
             autoLoop: true,
             cacheHours: 3,
+            conusDefaultZoom: 6,
         },
         approachCharts: {
             georefEnabled: true,

--- a/web/shared/stratux-client.js
+++ b/web/shared/stratux-client.js
@@ -174,9 +174,14 @@ class StratuxClient extends EventTarget {
         }
         this._connectTraffic();
         this._connectSituation();
+        // FIS-B weather channels connect in BOTH real and sim mode. Real Stratux always
+        // served these; the sim bridge (mock-stratux.py) now emits NEXRAD on /jsonio, so
+        // sim mode must subscribe too or FIS-B/NEXRAD can never be exercised on the ground.
+        this._connectWeather();
+        this._connectJsonio();
         if (!this._simMode) {
-            this._connectWeather();
-            this._connectJsonio();
+            // HTTP status/towers polling targets the real Stratux REST API (the sim bridge
+            // doesn't serve it), so keep these real-mode only.
             this._pollStatus();
             this._pollTowers();
         }

--- a/web/style.css
+++ b/web/style.css
@@ -5308,7 +5308,8 @@ body {
 .radar-page { position: fixed; top: 0; left: 0; right: 0; bottom: var(--tab-bar-height); z-index: 4000; background: var(--bg-primary); display: flex; flex-direction: column; }
 .radar-page-header { display: flex; align-items: center; gap: 12px; padding: 8px 12px; border-bottom: 2px solid var(--border-strong); }
 .radar-page-title { font-family: var(--font-ui); font-weight: 800; font-size: 18px; color: var(--text-primary); }
-.radar-page-close { margin-left: auto; min-width: var(--touch-min, 56px); min-height: var(--touch-min, 56px); font-size: 24px; font-weight: 800; background: var(--bg-surface); border: 1px solid var(--border); border-radius: 8px; color: var(--text-primary); }
+.radar-page-export { margin-left: auto; min-width: var(--touch-min, 56px); min-height: var(--touch-min, 56px); padding: 0 16px; font-family: var(--font-ui); font-size: 16px; font-weight: 700; background: var(--bg-surface); border: 1px solid var(--border); border-radius: 8px; color: var(--text-secondary); }
+.radar-page-close { min-width: var(--touch-min, 56px); min-height: var(--touch-min, 56px); font-size: 24px; font-weight: 800; background: var(--bg-surface); border: 1px solid var(--border); border-radius: 8px; color: var(--text-primary); }
 .radar-page-map { flex: 1; position: relative; }
 .radar-page-recenter { position: absolute; bottom: 92px; right: 16px; z-index: 500; min-height: var(--touch-preferred, 64px); padding: 0 18px; font-family: var(--font-ui); font-weight: 800; font-size: 16px; color: #fff; background: var(--accent); border: none; border-radius: 10px; }
 .radar-page-badge { position: static; }

--- a/web/style.css
+++ b/web/style.css
@@ -5305,7 +5305,7 @@ body {
 }
 
 /* ========== CONUS Radar Page (full-screen, own map) ========== */
-.radar-page { position: fixed; inset: 0; z-index: 4000; background: var(--bg-primary); display: flex; flex-direction: column; }
+.radar-page { position: fixed; top: 0; left: 0; right: 0; bottom: var(--tab-bar-height); z-index: 4000; background: var(--bg-primary); display: flex; flex-direction: column; }
 .radar-page-header { display: flex; align-items: center; gap: 12px; padding: 8px 12px; border-bottom: 2px solid var(--border-strong); }
 .radar-page-title { font-family: var(--font-ui); font-weight: 800; font-size: 18px; color: var(--text-primary); }
 .radar-page-close { margin-left: auto; min-width: var(--touch-min, 56px); min-height: var(--touch-min, 56px); font-size: 24px; font-weight: 800; background: var(--bg-surface); border: 1px solid var(--border); border-radius: 8px; color: var(--text-primary); }

--- a/web/style.css
+++ b/web/style.css
@@ -5304,6 +5304,15 @@ body {
     font-size: 13px; pointer-events: none;
 }
 
+/* ========== CONUS Radar Page (full-screen, own map) ========== */
+.radar-page { position: fixed; inset: 0; z-index: 4000; background: var(--bg-primary); display: flex; flex-direction: column; }
+.radar-page-header { display: flex; align-items: center; gap: 12px; padding: 8px 12px; border-bottom: 2px solid var(--border-strong); }
+.radar-page-title { font-family: var(--font-ui); font-weight: 800; font-size: 18px; color: var(--text-primary); }
+.radar-page-close { margin-left: auto; min-width: var(--touch-min, 56px); min-height: var(--touch-min, 56px); font-size: 24px; font-weight: 800; background: var(--bg-surface); border: 1px solid var(--border); border-radius: 8px; color: var(--text-primary); }
+.radar-page-map { flex: 1; position: relative; }
+.radar-page-recenter { position: absolute; bottom: 16px; right: 16px; z-index: 500; min-height: var(--touch-preferred, 64px); padding: 0 18px; font-family: var(--font-ui); font-weight: 800; font-size: 16px; color: #fff; background: var(--accent); border: none; border-radius: 10px; }
+.radar-page-badge { position: static; }
+
 /* ========== Checklist Overlay ========== */
 .checklist-page {
     position: fixed;

--- a/web/style.css
+++ b/web/style.css
@@ -6134,7 +6134,7 @@ body {
 .ftw-gauges {
     display: flex;
     flex-direction: row;
-    align-items: flex-end;
+    align-items: flex-start;
     gap: 6px;
 }
 
@@ -6142,13 +6142,13 @@ body {
     display: flex;
     flex-direction: column;
     align-items: center;
-    width: 52px;
+    width: 64px;
 }
 
 /* Tank label above bar */
 .ftw-tank::before {
     content: attr(data-label);
-    font-size: 11px;
+    font-size: 14px;
     font-weight: 700;
     letter-spacing: 0.1em;
     color: #546e7a;
@@ -6212,14 +6212,14 @@ body {
 
 /* Gallons readout */
 .ftw-gal {
-    font-size: 17px;
-    font-weight: 700;
+    font-size: 24px;
+    font-weight: 900;
     font-family: "Roboto Mono", "Courier New", monospace;
     color: #0d1b2a;
     margin-top: 4px;
     line-height: 1;
     letter-spacing: -0.02em;
-    min-width: 44px;
+    min-width: 56px;
     text-align: center;
 }
 
@@ -6229,23 +6229,23 @@ body {
 
 /* Tank timer */
 .ftw-timer {
-    font-size: 11px;
+    font-size: 14px;
     font-family: "Roboto Mono", "Courier New", monospace;
     color: #607d8b;
     line-height: 1.2;
-    min-height: 14px;
+    min-height: 17px;
     text-align: center;
 }
 
 /* Tank-select badge (tap to switch) */
 .ftw-badge {
     margin-top: 4px;
-    width: 44px;
-    height: 36px;
+    width: 52px;
+    height: 48px;
     border-radius: 4px;
     border: 2px solid #8a9ab0;
     background: #e8ecf0;
-    font-size: 14px;
+    font-size: 18px;
     font-weight: 700;
     letter-spacing: 0.06em;
     color: #546e7a;
@@ -6275,38 +6275,68 @@ body {
     text-align: center;
 }
 
-/* ── Center column (total + endurance + imbalance) ─────────────────── */
+/* ── Center column (total bar + totals + GPH + endurance) ──────────── */
 .ftw-center {
     display: flex;
     flex-direction: column;
     align-items: center;
-    justify-content: center;
-    min-width: 36px;
-    padding-bottom: 40px;   /* aligns visually with bar mid-point */
+    min-width: 44px;
     gap: 2px;
 }
 
+.ftw-center-label {
+    font-size: 14px;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    color: #546e7a;
+    margin-bottom: 3px;
+    line-height: 1;
+}
+
+.ftw-bar-wrap-center {
+    width: 44px;
+}
+
 .ftw-total-lbl {
-    font-size: 9px;
+    font-size: 11px;
     font-weight: 700;
     letter-spacing: 0.1em;
     color: #78909c;
     line-height: 1;
+    margin-top: 4px;
 }
 
 .ftw-total {
-    font-size: 14px;
+    font-size: 22px;
+    font-weight: 900;
+    font-family: "Roboto Mono", "Courier New", monospace;
+    color: #0d1b2a;
+    line-height: 1.2;
+}
+
+.ftw-flow-lbl {
+    font-size: 11px;
     font-weight: 700;
+    letter-spacing: 0.1em;
+    color: #78909c;
+    line-height: 1;
+    margin-top: 4px;
+}
+
+.ftw-flow {
+    font-size: 20px;
+    font-weight: 900;
     font-family: "Roboto Mono", "Courier New", monospace;
     color: #0d1b2a;
     line-height: 1.2;
 }
 
 .ftw-end {
-    font-size: 13px;
+    font-size: 18px;
     font-family: "Roboto Mono", "Courier New", monospace;
     color: #37474f;
     line-height: 1.2;
+    margin-top: 2px;
 }
 
 .ftw-imbal {

--- a/web/style.css
+++ b/web/style.css
@@ -5296,6 +5296,14 @@ body {
     mix-blend-mode: screen;
 }
 
+.radar-badge {
+    position: absolute; bottom: 8px; left: 8px; z-index: 500;
+    background: var(--bg-surface); color: var(--text-secondary);
+    border: 1px solid var(--border); border-radius: 6px;
+    padding: 4px 8px; font-family: var(--font-ui); font-weight: 700;
+    font-size: 13px; pointer-events: none;
+}
+
 /* ========== Checklist Overlay ========== */
 .checklist-page {
     position: fixed;

--- a/web/style.css
+++ b/web/style.css
@@ -5310,8 +5310,12 @@ body {
 .radar-page-title { font-family: var(--font-ui); font-weight: 800; font-size: 18px; color: var(--text-primary); }
 .radar-page-close { margin-left: auto; min-width: var(--touch-min, 56px); min-height: var(--touch-min, 56px); font-size: 24px; font-weight: 800; background: var(--bg-surface); border: 1px solid var(--border); border-radius: 8px; color: var(--text-primary); }
 .radar-page-map { flex: 1; position: relative; }
-.radar-page-recenter { position: absolute; bottom: 16px; right: 16px; z-index: 500; min-height: var(--touch-preferred, 64px); padding: 0 18px; font-family: var(--font-ui); font-weight: 800; font-size: 16px; color: #fff; background: var(--accent); border: none; border-radius: 10px; }
+.radar-page-recenter { position: absolute; bottom: 92px; right: 16px; z-index: 500; min-height: var(--touch-preferred, 64px); padding: 0 18px; font-family: var(--font-ui); font-weight: 800; font-size: 16px; color: #fff; background: var(--accent); border: none; border-radius: 10px; }
 .radar-page-badge { position: static; }
+.radar-page-loop { position: absolute; left: 16px; right: 16px; bottom: 16px; z-index: 500; display: flex; align-items: center; gap: 12px; padding: 8px 12px; background: var(--bg-surface); border: 1px solid var(--border); border-radius: 10px; }
+.radar-page-loop-btn { min-width: var(--touch-min, 56px); min-height: var(--touch-min, 56px); font-size: 24px; font-weight: 800; color: #fff; background: var(--accent); border: none; border-radius: 8px; }
+.radar-page-loop-time { font-family: var(--font-instrument); font-weight: 700; font-size: 18px; color: var(--text-primary); min-width: 64px; }
+.radar-page-loop-scrubber { flex: 1; min-height: var(--touch-min, 56px); accent-color: var(--accent); }
 
 /* ========== Checklist Overlay ========== */
 .checklist-page {


### PR DESCRIPTION
## Summary

- **NEXRAD CONUS radar**: Full FIS-B Regional + CONUS radar pipeline — product tagging, IDB persistence, loop playback, dedicated RadarPage with ownship overlay, and MORE drawer entry
- **Approach altitude fix**: Bust stale CIFP IDB cache (`cifp_bundle` → `cifp_bundle_v2`) so tablets with old pre-April-25 pipeline data (altitude1 10× too small) fetch the corrected bundle on next launch
- **Fuel tank overlay**: Center total bar gauge, live GPH readout, and larger/bolder type throughout for sunlight readability
- **MORE drawer**: Move Fuel Entry to Pre/Post flight; remove Weight & Balance from In-flight (stays in Pre/Post)

## Test plan

- [ ] Load an approach procedure (e.g., KLKR R06) — CORON/LAPRE should show 2,200/2,100 ft, not 220/210
- [ ] Verify NEXRAD radar loop plays on the CONUS RadarPage
- [ ] Verify fuel tank overlay shows GPH and center bar when engine data is live
- [ ] Confirm MORE drawer: Fuel Entry is under Pre/Post flight; Weight & Balance no longer in In-flight

🤖 Generated with [Claude Code](https://claude.com/claude-code)